### PR TITLE
Add issue execution guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,6 +13,12 @@ labels: ["bug"]
 
 ## Actual behavior
 
-## Spec reference
+## Acceptance criteria
+
+## OpenSpec impact
+
+## Spec references
+
+## Definition of done
 
 ## Environment

--- a/.github/ISSUE_TEMPLATE/contract_feedback.md
+++ b/.github/ISSUE_TEMPLATE/contract_feedback.md
@@ -13,4 +13,10 @@ labels: ["schemas", "templates"]
 
 ## Expected contract behavior
 
-## Spec reference
+## Acceptance criteria
+
+## OpenSpec impact
+
+## Spec references
+
+## Definition of done

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,8 +11,10 @@ labels: ["enhancement"]
 
 ## Proposed behavior
 
+## Acceptance criteria
+
 ## OpenSpec impact
 
-## Spec reference
+## Spec references
 
 ## Definition of done

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 - branch:
 - OpenSpec artifact:
 - spec reference:
-- issue:
+- issue: closes #
 
 ## Validation
 

--- a/.github/workflows/issue-execution-guard.yml
+++ b/.github/workflows/issue-execution-guard.yml
@@ -1,0 +1,134 @@
+name: Issue Execution Guard
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Flag stalled implementation issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const now = Date.now();
+            const graceHours = 24;
+            const staleLabel = "needs-execution";
+            const implementationLabels = new Set(["enhancement", "bug"]);
+            const ignoredTitles = new Set(["[feature] ", "[bug] ", "[contract] "]);
+
+            const { data: labels } = await github.rest.issues.listLabelsForRepo({
+              owner,
+              repo,
+              per_page: 100
+            });
+
+            if (!labels.some((label) => label.name === staleLabel)) {
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: staleLabel,
+                color: "B60205",
+                description: "Open issue has no assignee or linked PR within the execution grace period"
+              });
+            }
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100
+            });
+
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100
+            });
+
+            const linkedIssueNumbers = new Set();
+
+            for (const pull of pulls) {
+              const refs = [
+                pull.title ?? "",
+                pull.body ?? ""
+              ].join("\n");
+
+              for (const match of refs.matchAll(/#(\d+)/g)) {
+                linkedIssueNumbers.add(Number(match[1]));
+              }
+            }
+
+            const stalled = [];
+
+            for (const issue of issues) {
+              if (issue.pull_request) {
+                continue;
+              }
+
+              if (ignoredTitles.has(issue.title)) {
+                continue;
+              }
+
+              const labelNames = issue.labels.map((label) => typeof label === "string" ? label : label.name);
+              const isImplementationIssue = labelNames.some((name) => implementationLabels.has(name));
+
+              if (!isImplementationIssue) {
+                continue;
+              }
+
+              const ageHours = (now - Date.parse(issue.created_at)) / (1000 * 60 * 60);
+              const hasAssignee = issue.assignees.length > 0;
+              const hasLinkedPr = linkedIssueNumbers.has(issue.number);
+              const hasStaleLabel = labelNames.includes(staleLabel);
+
+              if (ageHours >= graceHours && !hasAssignee && !hasLinkedPr) {
+                stalled.push(issue.number);
+
+                if (!hasStaleLabel) {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    labels: [staleLabel]
+                  });
+
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    body: [
+                      "Execution guard: this implementation issue has been open for more than 24 hours with no assignee and no linked open pull request.",
+                      "",
+                      "To clear this guardrail, do one of the following:",
+                      "- assign an owner",
+                      "- open and link a pull request",
+                      "- close the issue if it is no longer active work"
+                    ].join("\n")
+                  });
+                }
+              } else if (hasStaleLabel) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  name: staleLabel
+                }).catch(() => {});
+              }
+            }
+
+            if (stalled.length > 0) {
+              core.setFailed(`Stalled implementation issues: ${stalled.map((n) => `#${n}`).join(", ")}`);
+            } else {
+              core.info("No stalled implementation issues found.");
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ The Day After Toolkit turns the book's argument into executable open source tool
 ## Branching Rule
 
 Never commit working changes directly to `main`. Every change starts on a proper branch, opens a pull request, and lands through review.
+If an issue is accepted for implementation, it must be assigned, moved into active execution, and have a pull request opened promptly. Open issues must not sit indefinitely with no execution owner and no branch-backed PR.
 
 ## Before You Start
 
@@ -57,6 +58,15 @@ Pull requests must not merge unless:
 - business logic unit coverage requirements for the affected area are satisfied
 - the implementation is aligned to the governing spec
 - review feedback is resolved
+
+## Issue Execution Rule
+
+Once an issue is approved for implementation, it needs an execution signal within one working day. The minimum acceptable signal is one of:
+
+- an assignee who owns execution
+- an open pull request linked to the issue
+
+If none of those signals exists, the issue is treated as stalled planning work and must be corrected before more tickets are opened.
 
 ## Issues
 

--- a/openspec/specs/repo-governance/spec.md
+++ b/openspec/specs/repo-governance/spec.md
@@ -52,6 +52,19 @@ The repository SHALL store living specs and change proposals using the OpenSpec 
 - WHEN they define the work
 - THEN they add or update the relevant OpenSpec spec or change proposal in-repo
 
+### Requirement: Active work needs an execution signal
+
+Accepted implementation issues SHALL show active execution within one working day.
+
+#### Scenario: Ticket exists but no one is executing it
+
+- GIVEN an open implementation issue exists
+- AND the issue has no assignee
+- AND the issue has no linked open pull request
+- WHEN the issue remains in that state longer than the allowed grace period
+- THEN repository automation flags it as stalled work
+- AND maintainers correct the status before opening more implementation tickets
+
 ### Requirement: Business logic must be fully unit tested
 
 The repository SHALL require deterministic business logic to reach 100% unit test coverage before merge.


### PR DESCRIPTION
## Summary
- require stronger ticket metadata across all issue templates
- require PRs to link a closing issue
- add governance and automation for stalled implementation issues

## OpenSpec artifact
- openspec/specs/repo-governance/spec.md

## Spec reference
- openspec/specs/repo-governance/spec.md
- CONTRIBUTING.md

## Issue
closes #34

## Validation
- Not run. Changes are limited to docs, templates, and GitHub workflow configuration.