### PR TITLE
Codify Ready and Blocked project statuses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,18 @@ Once an issue is approved for implementation, it needs an execution signal withi
 
 If none of those signals exists, the issue is treated as stalled planning work and must be corrected before more tickets are opened.
 
+## Project Statuses
+
+Use the project `Status` field deliberately. Avoid leaving executable work in `Todo` when the next state is already known.
+
+- `Ready` means the ticket has a governing spec reference, definition of done, and no known blocker. It is ready to be picked up for implementation.
+- `In Progress` means one owner is actively executing the ticket and driving its linked branch or pull request.
+- `Blocked` means work cannot move forward because of a concrete dependency, decision, or failing external condition. The blocking reason should be written in the issue or PR.
+- `Done` means the linked implementation has merged or the ticket has been otherwise fully resolved.
+
+Implementation tickets should normally move through `Ready` → `In Progress` → `Done`.
+Use `Blocked` instead of letting a ticket or PR silently stall.
+
 ## Issues
 
 Use the issue templates when possible so work lands in the project board and milestones cleanly. Link the spec section that governs the behavior you are proposing or changing.

--- a/openspec/specs/repo-governance/spec.md
+++ b/openspec/specs/repo-governance/spec.md
@@ -65,6 +65,23 @@ Accepted implementation issues SHALL show active execution within one working da
 - THEN repository automation flags it as stalled work
 - AND maintainers correct the status before opening more implementation tickets
 
+### Requirement: Project status reflects execution reality
+
+Implementation issues SHALL use the project status field to reflect whether work is ready, active, blocked, or done.
+
+#### Scenario: Ticket is fully specified and waiting to be picked up
+
+- GIVEN an implementation issue has spec references, definition of done, and no known blocker
+- WHEN the ticket is not yet actively owned
+- THEN its project status is `Ready`
+
+#### Scenario: Active work becomes blocked
+
+- GIVEN an implementation issue or linked pull request cannot progress because of a concrete blocker
+- WHEN execution cannot continue without that blocker being cleared
+- THEN its project status is `Blocked`
+- AND the blocking reason is recorded in the issue or pull request
+
 ### Requirement: Business logic must be fully unit tested
 
 The repository SHALL require deterministic business logic to reach 100% unit test coverage before merge.


### PR DESCRIPTION
## Summary
- document when tickets should be `Ready`, `In Progress`, `Blocked`, or `Done`
- add repo governance rules for `Ready` and `Blocked`
- align the live cdad board by moving executable open tickets into `Ready`

## OpenSpec artifact
- openspec/specs/repo-governance/spec.md

## Spec reference
- openspec/specs/repo-governance/spec.md
- CONTRIBUTING.md

## Issue
closes #38

## Validation
- Not run. Changes are limited to repo governance documentation and live project status updates.