### PR TITLE
Add roadmap command coverage tests

### DIFF
--- a/cli/src/commands/roadmap.test.ts
+++ b/cli/src/commands/roadmap.test.ts
@@ -1,0 +1,79 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { executeRoadmapCommand } from "./roadmap.js";
+
+describe("executeRoadmapCommand", () => {
+  it("writes a markdown roadmap and returns the terminal summary", async () => {
+    const workingDir = await mkdtemp(join(tmpdir(), "cdad-roadmap-command-"));
+    const reportPath = join(workingDir, "cdad-report.md");
+    const outputPath = join(workingDir, "cdad-roadmap.md");
+    const markdown = await readFile(
+      fileURLToPath(new URL("../../../docs/example-cdad-report.md", import.meta.url)),
+      "utf8"
+    );
+
+    await writeFile(reportPath, markdown, "utf8");
+
+    const execution = await executeRoadmapCommand(
+      {
+        input: reportPath,
+        output: outputPath,
+        format: "markdown"
+      },
+      {
+        prompt: vi.fn(async () => ({
+          businessCriticality: 3 as const,
+          agentTouchpointFrequency: 1 as const
+        })),
+        now: () => new Date("2026-04-08T00:00:00Z")
+      }
+    );
+
+    const written = await readFile(outputPath, "utf8");
+
+    expect(execution.output).toContain("cdad roadmap — Transformation Roadmap");
+    expect(execution.output).toContain(`Roadmap saved to: ${outputPath}`);
+    expect(execution.result.outputPath).toBe(outputPath);
+    expect(written).toContain("generated_by: cdad roadmap");
+    expect(written).toContain("generated_at: 2026-04-08T00:00:00.000Z");
+  });
+
+  it("writes json output and normalizes the basename when the output path uses markdown naming", async () => {
+    const workingDir = await mkdtemp(join(tmpdir(), "cdad-roadmap-command-json-"));
+    const reportPath = join(workingDir, "cdad-report.md");
+    const requestedOutputPath = join(workingDir, "cdad-roadmap.md");
+    const markdown = await readFile(
+      fileURLToPath(new URL("../../../docs/example-cdad-report.md", import.meta.url)),
+      "utf8"
+    );
+
+    await writeFile(reportPath, markdown, "utf8");
+
+    const execution = await executeRoadmapCommand(
+      {
+        input: reportPath,
+        output: requestedOutputPath,
+        format: "json"
+      },
+      {
+        prompt: vi.fn(async () => ({
+          businessCriticality: 2 as const,
+          agentTouchpointFrequency: 2 as const
+        })),
+        now: () => new Date("2026-04-08T00:00:00Z")
+      }
+    );
+
+    const jsonOutputPath = join(workingDir, "cdad-roadmap.json");
+    const written = JSON.parse(await readFile(jsonOutputPath, "utf8")) as Record<string, unknown>;
+
+    expect(execution.result.outputPath).toBe(jsonOutputPath);
+    expect(written.generatedBy).toBe("cdad roadmap");
+    expect(Array.isArray(written.capabilities)).toBe(true);
+  });
+});

--- a/cli/src/commands/roadmap.ts
+++ b/cli/src/commands/roadmap.ts
@@ -2,9 +2,21 @@
  * Implements cdad roadmap.
  */
 
+import type { RoadmapCommandOptions, RoadmapRunResult, RoadmapRunnerDependencies } from "../roadmap/runner.js";
 import type { Command } from "commander";
 
 import { runRoadmapCommand } from "../roadmap/runner.js";
+
+interface RoadmapCliOptions {
+  readonly input: string;
+  readonly output: string;
+  readonly format: "markdown" | "json";
+}
+
+export interface RoadmapCommandExecution {
+  readonly result: RoadmapRunResult;
+  readonly output: string;
+}
 
 export function registerRoadmapCommand(program: Command): void {
   program
@@ -13,21 +25,39 @@ export function registerRoadmapCommand(program: Command): void {
     .option("--input <path>", "Input report path", "cdad-report.md")
     .option("--output <path>", "Output roadmap path", "cdad-roadmap.md")
     .option("--format <type>", "Output format: markdown | json", "markdown")
-    .action(async (options: { input: string; output: string; format: "markdown" | "json" }): Promise<void> => {
+    .action(async (options: RoadmapCliOptions): Promise<void> => {
       try {
-        const format = options.format === "json" ? "json" : "markdown";
-        const result = await runRoadmapCommand({
-          inputPath: options.input,
-          outputPath: options.output,
-          format
-        });
+        const execution = await executeRoadmapCommand(options);
 
-        console.log(result.terminal);
+        console.log(execution.output);
       } catch (error) {
         console.error(formatRoadmapCommandError(error));
         process.exitCode = 1;
       }
     });
+}
+
+export async function executeRoadmapCommand(
+  options: RoadmapCliOptions,
+  dependencies: Partial<RoadmapRunnerDependencies> = {}
+): Promise<RoadmapCommandExecution> {
+  const result = await runRoadmapCommand(
+    {
+      inputPath: options.input,
+      outputPath: options.output,
+      format: normalizeRoadmapFormat(options.format)
+    },
+    dependencies
+  );
+
+  return {
+    result,
+    output: result.terminal
+  };
+}
+
+function normalizeRoadmapFormat(format: RoadmapCommandOptions["format"]): RoadmapCommandOptions["format"] {
+  return format === "json" ? "json" : "markdown";
 }
 
 function formatRoadmapCommandError(error: unknown): string {


### PR DESCRIPTION
## Summary
- export roadmap command execution for direct test coverage
- add roadmap command tests for markdown and json output flows
- create the first visible implementation slice for issue #25

## OpenSpec artifact
- ref/the-day-after-toolkit-spec.md

## Spec reference
- `ref/the-day-after-toolkit-spec.md` — `cdad roadmap`
- `ref/the-day-after-toolkit-spec.md` — `Tests` and `Coverage gate`

## Issue
refs #25

## Validation
- Not run locally in this environment.
- This PR is the first visible test-coverage slice for #25 and will rely on CI for verification.