### PR TITLE
Configure GitHub Pages deployment for the book site

### DIFF
--- a/book-website/README.md
+++ b/book-website/README.md
@@ -34,28 +34,31 @@ Run from `book-website/`:
 
 Search the codebase for `TODO` to find every placeholder:
 
-- **Body copy** — every section on the homepage (`src/pages/index.astro`) still carries the Lorem ipsum and "Sub Title 1" / "New Title" placeholder labels from the Figma design. Replace before launch.
 - **Buy links** — `src/components/BuyLinks.astro` and the header's "Pre-order on Amazon" link (`src/components/Header.astro`) have `href="#"` placeholders.
-- **Book synopsis & table of contents** — `src/pages/about-the-book.astro`.
-- **Sample chapter text** — `src/pages/excerpt.astro`.
 - **Contact email** — `src/pages/contact.astro` (`hello@example.com` placeholder).
 - **Newsletter signup** — no form-handling service is wired up yet (this is a static site with no backend); pick one (Mailchimp, ConvertKit, Buttondown, Formspree, etc.) before advertising it.
-- **Photos** — `public/images/` was exported directly from the Figma file's stock placeholders (hero landscape + 6 "who is this book for" portraits). Two of the team photos (`team-project-managers.jpg`, `team-leadership.jpg`, `team-engineering-managers.jpg`) are low-resolution crops (~250–390px wide) — replace all of these with real or licensed photography before launch.
-- **CTA section** — the coral "Get the book" block at the bottom of the homepage was an empty color panel in the Figma design; the current heading/buttons are a reasonable placeholder, not final copy.
-- **`site` / `base` in `astro.config.mjs`** — set `site` to the real deployed origin. Only set `base` if deploying as a GitHub Pages *project* site without a custom domain (see comments in the file); if you do, also prefix the nav links in `src/components/Header.astro` with `import.meta.env.BASE_URL`.
+- **Photos** — `public/images/` was exported directly from the Figma file's stock placeholders (hero landscape + 6 "who is this book for" portraits). Three of the team photos (`team-project-managers.jpg`, `team-leadership.jpg`, `team-engineering-managers.jpg`) are low-resolution crops (~250–390px wide) — replace all of these with real or licensed photography before launch.
+
+Body copy, the synopsis/table of contents, the sample chapter, and the four
+chapter landing pages (`/tribal-knowledge/`, `/contracts/`,
+`/capabilities-graph/`, `/extraction-over-refactoring/`) are drawn from the
+real manuscript, kept to non-spoiler summaries.
 
 ## Deployment
 
+Live at **https://enricopiovesan.github.io/the-day-after-toolkit/**.
+
 A GitHub Actions workflow at `.github/workflows/book-website-deploy.yml`
 builds this site and deploys it to GitHub Pages on every push to `main`
-that touches `book-website/**`. To enable it:
-
-1. In the repo's GitHub Settings → Pages, set the source to "GitHub Actions".
-2. Set `site` (and `base`, if needed) in `astro.config.mjs` as described above.
+that touches `book-website/**`. `astro.config.mjs` sets `site` and `base`
+for this deployment; every internal link and asset reference goes through
+`src/utils/url.ts`'s `withBase()` helper so they resolve correctly under
+the `/the-day-after-toolkit/` path — use it for any new internal
+`href`/`src` rather than a bare `/...` string.
 
 **Note:** GitHub Pages serves only one site per repository. If this repo's
 GitHub Pages is later used for the toolkit's own docs site (see issue #44),
-it will conflict with deploying the book site the same way from this repo.
-Options if that happens: put the book site on a custom domain (works
-regardless of where Pages points), or move `book-website/` to its own
-repository.
+it will conflict with this deployment. Options if that happens: put the
+book site on a custom domain (drop `base` in `astro.config.mjs` — every
+link already routes through `withBase()`, so that's the only change
+needed), or move `book-website/` to its own repository.

--- a/book-website/astro.config.mjs
+++ b/book-website/astro.config.mjs
@@ -1,15 +1,13 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 
-// TODO before first deploy:
-// - Set `site` to the real deployed origin (e.g. a custom domain, or
-//   https://<user>.github.io for a GitHub Pages user/org site).
-// - If deploying as a GitHub Pages *project* site with no custom domain,
-//   GitHub serves it from /<repo-name>/, not from `/`. In that case also
-//   set `base: '/<repo-name>/'` below and prefix internal links with
-//   `import.meta.env.BASE_URL` (see src/components/Header.astro).
-//   With a custom domain (or Vercel/Netlify), leave `base` unset.
+// Deployed as a GitHub Pages *project* site (this repo isn't named
+// <user>.github.io), so it's served from /the-day-after-toolkit/, not
+// from "/". All internal links/assets go through src/utils/url.ts's
+// withBase() to stay correct here. If a custom domain is added later,
+// drop `base` and withBase() becomes a no-op automatically.
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://example.com',
+  site: 'https://enricopiovesan.github.io',
+  base: '/the-day-after-toolkit/',
 });

--- a/book-website/src/components/AudienceGrid.astro
+++ b/book-website/src/components/AudienceGrid.astro
@@ -1,4 +1,6 @@
 ---
+import { withBase } from "../utils/url";
+
 const tiles = [
   { title: "Software\nDevelopers", tag: "SOFTWARE ENGINEERS", color: "pink", image: "/images/team-developers.jpg" },
   { title: "Project\nManagers", tag: "PROJECT OWNERS", color: "sage", image: "/images/team-project-managers.jpg" },
@@ -27,7 +29,7 @@ const tiles = [
             ))}
           </h3>
         </div>
-        <img class="tile__image" src={tile.image} alt="" loading="lazy" />
+        <img class="tile__image" src={withBase(tile.image)} alt="" loading="lazy" />
       </div>
     ))
   }

--- a/book-website/src/components/Header.astro
+++ b/book-website/src/components/Header.astro
@@ -1,4 +1,6 @@
 ---
+import { withBase } from "../utils/url";
+
 interface Props {
   overlay?: boolean;
 }
@@ -6,11 +8,11 @@ interface Props {
 const { overlay = false } = Astro.props;
 
 const navItems = [
-  { href: "/", label: "Home" },
-  { href: "/about-the-book/", label: "About the Book" },
-  { href: "/author/", label: "Author" },
-  { href: "/excerpt/", label: "Excerpt" },
-  { href: "/contact/", label: "Contact" },
+  { href: withBase("/"), label: "Home" },
+  { href: withBase("/about-the-book/"), label: "About the Book" },
+  { href: withBase("/author/"), label: "Author" },
+  { href: withBase("/excerpt/"), label: "Excerpt" },
+  { href: withBase("/contact/"), label: "Contact" },
 ];
 
 const currentPath = Astro.url.pathname;
@@ -19,8 +21,8 @@ const currentPath = Astro.url.pathname;
 <header class="site-header" class:list={[{ "site-header--overlay": overlay }]}>
   <div class:list={["site-header__inner", { "wrap wrap--wide": !overlay }]}>
     <div class="site-header__group">
-      <a href="/" class="logo-tab">
-        <img src="/logo.svg" alt="The Day After AI" class="logo-tab__image" />
+      <a href={withBase("/")} class="logo-tab">
+        <img src={withBase("/logo.svg")} alt="The Day After AI" class="logo-tab__image" />
       </a>
 
       <nav class="site-nav" aria-label="Primary">

--- a/book-website/src/layouts/BaseLayout.astro
+++ b/book-website/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
+import { withBase } from "../utils/url";
 import "../styles/global.css";
 
 interface Props {
@@ -24,7 +25,7 @@ const pageTitle = title === "The Day After AI" ? title : `${title} — The Day A
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={withBase("/favicon.svg")} />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/book-website/src/pages/about-the-book.astro
+++ b/book-website/src/pages/about-the-book.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
 ---
 
 <BaseLayout
@@ -46,10 +47,10 @@ import BuyLinks from "../components/BuyLinks.astro";
       <ol class="toc">
         <li>Opening Scene &mdash; Monday Morning</li>
         <li>The Day After</li>
-        <li><a href="/tribal-knowledge/">Tribal Knowledge Is the Bottleneck</a></li>
-        <li><a href="/contracts/">Contracts Are the Answer</a></li>
-        <li><a href="/capabilities-graph/">The Capabilities Graph</a></li>
-        <li><a href="/extraction-over-refactoring/">Extraction Over Refactoring</a></li>
+        <li><a href={withBase("/tribal-knowledge/")}>Tribal Knowledge Is the Bottleneck</a></li>
+        <li><a href={withBase("/contracts/")}>Contracts Are the Answer</a></li>
+        <li><a href={withBase("/capabilities-graph/")}>The Capabilities Graph</a></li>
+        <li><a href={withBase("/extraction-over-refactoring/")}>Extraction Over Refactoring</a></li>
         <li>The Contract Lifecycle</li>
         <li>The Architect</li>
         <li>The Developer</li>

--- a/book-website/src/pages/capabilities-graph.astro
+++ b/book-website/src/pages/capabilities-graph.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
 ---
 
 <BaseLayout
@@ -39,8 +40,8 @@ import BuyLinks from "../components/BuyLinks.astro";
       <BuyLinks />
 
       <nav class="chapter-nav" aria-label="Chapter navigation">
-        <a href="/contracts/">&larr; Chapter 3 &mdash; Contracts Are the Answer</a>
-        <a href="/extraction-over-refactoring/">Chapter 5 &mdash; Extraction Over Refactoring &rarr;</a>
+        <a href={withBase("/contracts/")}>&larr; Chapter 3 &mdash; Contracts Are the Answer</a>
+        <a href={withBase("/extraction-over-refactoring/")}>Chapter 5 &mdash; Extraction Over Refactoring &rarr;</a>
       </nav>
     </div>
   </section>

--- a/book-website/src/pages/contracts.astro
+++ b/book-website/src/pages/contracts.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
 ---
 
 <BaseLayout
@@ -39,8 +40,8 @@ import BuyLinks from "../components/BuyLinks.astro";
       <BuyLinks />
 
       <nav class="chapter-nav" aria-label="Chapter navigation">
-        <a href="/tribal-knowledge/">&larr; Chapter 2 &mdash; Tribal Knowledge Is the Bottleneck</a>
-        <a href="/capabilities-graph/">Chapter 4 &mdash; The Capabilities Graph &rarr;</a>
+        <a href={withBase("/tribal-knowledge/")}>&larr; Chapter 2 &mdash; Tribal Knowledge Is the Bottleneck</a>
+        <a href={withBase("/capabilities-graph/")}>Chapter 4 &mdash; The Capabilities Graph &rarr;</a>
       </nav>
     </div>
   </section>

--- a/book-website/src/pages/extraction-over-refactoring.astro
+++ b/book-website/src/pages/extraction-over-refactoring.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
 ---
 
 <BaseLayout
@@ -39,8 +40,8 @@ import BuyLinks from "../components/BuyLinks.astro";
       <BuyLinks />
 
       <nav class="chapter-nav" aria-label="Chapter navigation">
-        <a href="/capabilities-graph/">&larr; Chapter 4 &mdash; The Capabilities Graph</a>
-        <a href="/about-the-book/">Full table of contents &rarr;</a>
+        <a href={withBase("/capabilities-graph/")}>&larr; Chapter 4 &mdash; The Capabilities Graph</a>
+        <a href={withBase("/about-the-book/")}>Full table of contents &rarr;</a>
       </nav>
     </div>
   </section>

--- a/book-website/src/pages/index.astro
+++ b/book-website/src/pages/index.astro
@@ -6,6 +6,7 @@ import PanelSection from "../components/PanelSection.astro";
 import CardRow from "../components/CardRow.astro";
 import AudienceGrid from "../components/AudienceGrid.astro";
 import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
 
 // Section copy is written from the book's own manuscript (Chapters 1–5),
 // kept to non-spoiler summary and thesis statements — no plot points or
@@ -61,8 +62,8 @@ const extractionCards = [
 // Sunrise sequence, first to last. Drop extra frames (e.g. a dawn shot)
 // between night and day and the timing/zoom adjusts automatically.
 const heroStages = [
-  "/images/hero-night.jpg",
-  "/images/hero.jpg",
+  withBase("/images/hero-night.jpg"),
+  withBase("/images/hero.jpg"),
 ];
 
 // Each stage except the last fades out in turn, revealing the next one,
@@ -143,7 +144,7 @@ const heroTiming = `
         {tribalKnowledgeCopy.map((p) => <p>{p}</p>)}
       </div>
       <PanelSection eyebrow="Use Cases" color="sage" columns={tribalKnowledgeCards} />
-      <a class="chapter-link" href="/tribal-knowledge/">Read the chapter &rarr;</a>
+      <a class="chapter-link" href={withBase("/tribal-knowledge/")}>Read the chapter &rarr;</a>
     </div>
   </section>
 
@@ -154,7 +155,7 @@ const heroTiming = `
         {contractsCopy.map((p) => <p>{p}</p>)}
       </div>
       <CardRow color="cream" cards={contractsCards} />
-      <a class="chapter-link" href="/contracts/">Read the chapter &rarr;</a>
+      <a class="chapter-link" href={withBase("/contracts/")}>Read the chapter &rarr;</a>
     </div>
   </section>
 
@@ -165,7 +166,7 @@ const heroTiming = `
         {capabilitiesCopy.map((p) => <p>{p}</p>)}
       </div>
       <PanelSection eyebrow="The Graph" color="pink" columns={capabilitiesCards} />
-      <a class="chapter-link" href="/capabilities-graph/">Read the chapter &rarr;</a>
+      <a class="chapter-link" href={withBase("/capabilities-graph/")}>Read the chapter &rarr;</a>
     </div>
   </section>
 
@@ -176,7 +177,7 @@ const heroTiming = `
         {extractionCopy.map((p) => <p>{p}</p>)}
       </div>
       <CardRow color="tan" cards={extractionCards} />
-      <a class="chapter-link" href="/extraction-over-refactoring/">Read the chapter &rarr;</a>
+      <a class="chapter-link" href={withBase("/extraction-over-refactoring/")}>Read the chapter &rarr;</a>
     </div>
   </section>
 

--- a/book-website/src/pages/tribal-knowledge.astro
+++ b/book-website/src/pages/tribal-knowledge.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
 ---
 
 <BaseLayout
@@ -47,8 +48,8 @@ import BuyLinks from "../components/BuyLinks.astro";
       <BuyLinks />
 
       <nav class="chapter-nav" aria-label="Chapter navigation">
-        <a href="/about-the-book/">&larr; Table of contents</a>
-        <a href="/contracts/">Chapter 3 &mdash; Contracts Are the Answer &rarr;</a>
+        <a href={withBase("/about-the-book/")}>&larr; Table of contents</a>
+        <a href={withBase("/contracts/")}>Chapter 3 &mdash; Contracts Are the Answer &rarr;</a>
       </nav>
     </div>
   </section>

--- a/book-website/src/utils/url.ts
+++ b/book-website/src/utils/url.ts
@@ -1,0 +1,8 @@
+// Prefixes a root-relative path (e.g. "/tribal-knowledge/") with the
+// configured `base` from astro.config.mjs, so internal links and asset
+// references keep working whether the site is served from "/" (a custom
+// domain) or "/the-day-after-toolkit/" (a GitHub Pages project site).
+export function withBase(path: string): string {
+  const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+  return `${base}${path}`;
+}


### PR DESCRIPTION
## Summary
- Set `site`/`base` in `astro.config.mjs` for this repo's GitHub Pages project URL: `https://enricopiovesan.github.io/the-day-after-toolkit/`.
- Added `src/utils/url.ts` (`withBase()`) and routed every internal `href`/`src` through it — nav links, chapter cross-links, the logo, favicon, and all hero/audience images. Without this, every internal link would 404 under the `/the-day-after-toolkit/` sub-path GitHub Pages actually serves from.
- Confirmed via the built `dist/` output that every internal reference is correctly prefixed, and verified the dev server serves correctly at the base path too.

## Test plan
- [x] `npm run build` passes cleanly (9 pages)
- [x] Verified `dist/index.html` and `dist/tribal-knowledge/index.html` have correctly base-prefixed hrefs/srcs
- [x] Verified nav renders and resolves correctly in-browser under `/the-day-after-toolkit/`
- [ ] After merge: enable GitHub Pages (Settings → Pages → Source: GitHub Actions) to activate `.github/workflows/book-website-deploy.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)