### PR TITLE
Write full site content: chapters, appendix, and 9 SEO clusters

### DIFF
--- a/book-website/src/components/Footer.astro
+++ b/book-website/src/components/Footer.astro
@@ -1,23 +1,118 @@
 ---
+import { withBase } from "../utils/url";
+
 const year = new Date().getFullYear();
+
+const sitemapColumns = [
+  {
+    heading: "The Book",
+    links: [
+      { href: withBase("/about-the-book/"), label: "About the Book" },
+      { href: withBase("/excerpt/"), label: "Free Excerpt" },
+      { href: withBase("/author/"), label: "Author" },
+      { href: withBase("/why-c-dad/"), label: "Why C-DAD" },
+    ],
+  },
+  {
+    heading: "The Model",
+    links: [
+      { href: withBase("/core-model/"), label: "Core Model" },
+      { href: withBase("/how-c-dad-works/"), label: "How C-DAD Works" },
+      { href: withBase("/glossary/"), label: "Glossary" },
+      { href: withBase("/appendix/"), label: "Appendix" },
+    ],
+  },
+  {
+    heading: "The Case",
+    links: [
+      { href: withBase("/comparisons/"), label: "Comparisons" },
+      { href: withBase("/use-cases/"), label: "Use Cases" },
+      { href: withBase("/proof/"), label: "Proof" },
+      { href: withBase("/examples/"), label: "Examples" },
+    ],
+  },
+  {
+    heading: "The Toolkit",
+    links: [
+      { href: withBase("/toolkit/"), label: "Toolkit Overview" },
+      { href: withBase("/toolkit/installation/"), label: "Installation" },
+      { href: withBase("/faq/"), label: "FAQ" },
+      { href: withBase("/contact/"), label: "Contact" },
+    ],
+  },
+];
 ---
 
 <footer class="site-footer">
-  <div class="wrap wrap--wide site-footer__inner">
-    <p>&copy; {year} Enrico Piovesan. All rights reserved.</p>
-    <ul>
-      <li><a href="https://github.com/enricopiovesan">GitHub</a></li>
-      <li><a href="https://medium.com/software-architecture-in-the-age-of-ai">Medium</a></li>
-      <li><a href="https://github.com/enricopiovesan/the-day-after-toolkit">Companion Toolkit</a></li>
-    </ul>
+  <div class="wrap wrap--wide">
+    <div class="site-footer__sitemap">
+      {
+        sitemapColumns.map((column) => (
+          <div class="site-footer__column">
+            <p class="site-footer__heading">{column.heading}</p>
+            <ul class="site-footer__links">
+              {column.links.map((link) => (
+                <li>
+                  <a href={link.href}>{link.label}</a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))
+      }
+    </div>
+
+    <div class="site-footer__inner">
+      <p>&copy; {year} Enrico Piovesan. All rights reserved.</p>
+      <ul class="site-footer__external">
+        <li><a href="https://github.com/enricopiovesan">GitHub</a></li>
+        <li><a href="https://medium.com/software-architecture-in-the-age-of-ai">Medium</a></li>
+        <li><a href="https://github.com/enricopiovesan/the-day-after-toolkit">Companion Toolkit</a></li>
+      </ul>
+    </div>
   </div>
 </footer>
 
 <style>
   .site-footer {
-    padding: 2rem 0;
+    padding: 3rem 0 2rem;
     color: var(--text-muted);
     font-size: 0.9rem;
+    border-top: 1px solid var(--border);
+    margin-top: 3rem;
+  }
+
+  .site-footer__sitemap {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 2rem;
+    padding-bottom: 2.5rem;
+  }
+
+  .site-footer__heading {
+    margin: 0 0 0.75rem;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text);
+  }
+
+  .site-footer__links {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .site-footer__links a {
+    color: var(--text-muted);
+    text-decoration: none;
+  }
+
+  .site-footer__links a:hover {
+    color: var(--coral);
   }
 
   .site-footer__inner {
@@ -26,13 +121,15 @@ const year = new Date().getFullYear();
     justify-content: space-between;
     flex-wrap: wrap;
     gap: 1rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
   }
 
   .site-footer p {
     margin: 0;
   }
 
-  .site-footer ul {
+  .site-footer__external {
     list-style: none;
     display: flex;
     gap: 1.25rem;
@@ -47,5 +144,11 @@ const year = new Date().getFullYear();
 
   .site-footer a:hover {
     color: var(--coral);
+  }
+
+  @media (max-width: 700px) {
+    .site-footer__sitemap {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
   }
 </style>

--- a/book-website/src/layouts/BaseLayout.astro
+++ b/book-website/src/layouts/BaseLayout.astro
@@ -12,11 +12,11 @@ interface Props {
 
 const {
   title,
-  description = "Tribal knowledge is the hidden bottleneck stopping AI agents from working safely in your codebase. The Day After is the operating model for making software legible — to your team and to the agents building it with you.",
+  description = "Tribal knowledge is the hidden bottleneck stopping AI agents from working safely in your codebase. The Day After is the operating model for making software legible, to your team and to the agents building it with you.",
   hideHeader = false,
 } = Astro.props;
 
-const pageTitle = title === "The Day After AI" ? title : `${title} — The Day After AI`;
+const pageTitle = title === "The Day After AI" ? title : `${title}: The Day After AI`;
 ---
 
 <html lang="en">

--- a/book-website/src/pages/about-the-book.astro
+++ b/book-website/src/pages/about-the-book.astro
@@ -6,7 +6,7 @@ import { withBase } from "../utils/url";
 
 <BaseLayout
   title="About the Book"
-  description="What The Day After covers, chapter by chapter: why tribal knowledge breaks AI agents, why contracts — not more docs — are the fix, and the capability graph that makes a codebase legible to humans and agents alike."
+  description="What The Day After covers, chapter by chapter: why tribal knowledge breaks AI agents, why contracts (not more docs) are the fix, and the capability graph that makes a codebase legible to humans and agents alike."
 >
   <section class="section">
     <div class="wrap">
@@ -30,14 +30,14 @@ import { withBase } from "../utils/url";
         concrete recipe for that shift. The organizations that make it first
         will compound that advantage with every agent generation that
         follows. The ones that don't will find themselves outpaced not by
-        better technology, but by better structure &mdash; structure their
+        better technology, but by better structure, the kind their
         competitors built while the window was still open.
       </p>
 
       <h2>Who it's for</h2>
       <ul>
         <li>Architects designing the capability graph and writing the contracts that govern it.</li>
-        <li>Developers and tech leads shipping inside &mdash; and outside &mdash; a legacy codebase.</li>
+        <li>Developers and tech leads shipping inside and outside a legacy codebase.</li>
         <li>PMs and POs deciding what gets extracted first.</li>
         <li>Designers working in systems that now have to explain themselves to a machine.</li>
         <li>Engineering leaders deciding how much autonomy to hand to AI agents, and how to restructure for it.</li>
@@ -45,7 +45,7 @@ import { withBase } from "../utils/url";
 
       <h2>Table of contents</h2>
       <ol class="toc">
-        <li>Opening Scene &mdash; Monday Morning</li>
+        <li>Opening Scene: Monday Morning</li>
         <li>The Day After</li>
         <li><a href={withBase("/tribal-knowledge/")}>Tribal Knowledge Is the Bottleneck</a></li>
         <li><a href={withBase("/contracts/")}>Contracts Are the Answer</a></li>
@@ -58,7 +58,7 @@ import { withBase } from "../utils/url";
         <li>The Designer</li>
         <li>The Leadership Team</li>
         <li>The Company That Gets There First</li>
-        <li>Appendix &mdash; contract schema reference, legibility audit framework, extraction priority matrix, glossary</li>
+        <li>Appendix: contract schema reference, legibility audit framework, extraction priority matrix, glossary</li>
       </ol>
 
       <BuyLinks />

--- a/book-website/src/pages/appendix.astro
+++ b/book-website/src/pages/appendix.astro
@@ -1,0 +1,103 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="Appendix"
+  description="Understanding what a contract is and knowing how to write one are different things. The appendix is where the book hands over the actual artifacts: schemas, an audit framework, and a priority matrix."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Part IV &middot; The Toolkit</p>
+      <h1>Appendix</h1>
+
+      <p>
+        Understanding what a contract is and knowing how to write one are
+        different things. The twelve chapters before this build the
+        argument with precision: what a contract declares, why it fixes
+        the legibility problem, how it composes into a graph, what each
+        role in an organization owes to it and reads from it. A reader
+        who's worked through those chapters understands the model. What
+        they don't have yet is the artifact.
+      </p>
+      <p>
+        The appendix hands over three of them, each built against the same
+        running example from the book, the payment retry policy from
+        Meridian's payments domain, the capability that opens the book and
+        never really leaves it.
+      </p>
+
+      <ul class="appendix-list">
+        <li>
+          <a href={withBase("/appendix/contract-schema-reference/")}>Contract Schema Reference</a>
+          <p>The minimum viable contract and the extended contract, shown fully filled in, so the first one you write doesn't start from a blank page.</p>
+        </li>
+        <li>
+          <a href={withBase("/appendix/legibility-audit-framework/")}>Legibility Audit Framework</a>
+          <p>How to score what your system currently makes legible, and what it doesn't, before you decide what to extract first.</p>
+        </li>
+        <li>
+          <a href={withBase("/appendix/extraction-priority-matrix/")}>Extraction Priority Matrix</a>
+          <p>A way to rank which capabilities are worth contracting first, based on risk and how often they actually get touched.</p>
+        </li>
+      </ul>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Chapter navigation">
+        <a href={withBase("/company-that-gets-there-first/")}>&larr; Chapter 12: The Company That Gets There First</a>
+        <a href={withBase("/about-the-book/")}>Full table of contents &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .appendix-list {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 1.25rem;
+    margin: 2rem 0;
+  }
+
+  .appendix-list a {
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: var(--border);
+    text-underline-offset: 0.15em;
+  }
+
+  .appendix-list a:hover {
+    color: var(--coral);
+    text-decoration-color: currentColor;
+  }
+
+  .appendix-list p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/appendix/contract-schema-reference.astro
+++ b/book-website/src/pages/appendix/contract-schema-reference.astro
@@ -1,0 +1,76 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Contract Schema Reference"
+  description="The minimum viable contract and the extended contract, both shown against the same real capability, so the first contract you write doesn't start from a blank page."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Appendix A</p>
+      <h1>Contract Schema Reference</h1>
+
+      <p>
+        Understanding what a contract is and knowing how to write one are
+        different things. This is the artifact that closes that gap: two
+        schemas, both shown against the same capability, the payment retry
+        policy from Meridian's payments domain that runs through the whole
+        book as the example of what undeclared knowledge actually costs.
+      </p>
+      <p>
+        The <strong>minimum viable contract</strong> is the starting
+        point. It contains the fields a team needs to make one capability
+        navigable today, whether that's the first contract in a brownfield
+        extraction or the first contract a new capability ships with from
+        sprint one. The <strong>extended contract</strong> adds
+        dependency, behavioral, and evolutionary layers on top, for the
+        capabilities where it's worth going past sufficient.
+      </p>
+      <p>
+        Neither schema is done when every field is filled in. It's done
+        when it passes the same diagnostic used throughout the book: could
+        a capable engineer with no tribal knowledge navigate this
+        capability safely using only what the contract makes available?
+        The minimum viable contract is built to clear that bar. The
+        extended contract is built to clear it with room to spare.
+      </p>
+      <p>
+        The full YAML schemas and a completed working example live in the
+        companion repository, alongside the open-source CLI that scaffolds
+        and validates contracts against them.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/appendix/")}>&larr; Appendix overview</a>
+        <a href={withBase("/appendix/legibility-audit-framework/")}>Legibility Audit Framework &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/appendix/extraction-priority-matrix.astro
+++ b/book-website/src/pages/appendix/extraction-priority-matrix.astro
@@ -1,0 +1,76 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Extraction Priority Matrix"
+  description="Business criticality, tribal knowledge density, and agent touchpoint frequency, multiplied together, not added. How to rank what actually gets contracted first."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Appendix C</p>
+      <h1>Extraction Priority Matrix</h1>
+
+      <p>
+        A legibility audit tells you where the tribal knowledge is. It
+        doesn't tell you what to fix first. That's a separate question,
+        and the answer isn't just "whatever scored worst."
+      </p>
+      <p>
+        Three axes decide it. Business criticality: how much revenue or
+        compliance risk actually sits inside the capability. Tribal
+        knowledge density: pulled straight from the legibility audit
+        score. Agent touchpoint frequency: how often agents are actually
+        going to hit this capability once they're working in the system.
+      </p>
+      <p>
+        The rule is to multiply those three numbers, never add them. A
+        capability that's mission-critical and completely opaque but that
+        agents will almost never touch shouldn't jump the line ahead of
+        one that's moderately risky and gets hit constantly. Multiplying
+        keeps a zero on any axis from letting a capability sneak to the
+        front, because a zero anywhere means it isn't a real candidate
+        yet.
+      </p>
+      <p>
+        The result sorts into phases. A perfect score of 9 is phase one,
+        extract now. Scores of 4 to 8 are phase two. Scores of 1 to 3 are
+        phase three, worth tracking but not urgent. A score of 0 means the
+        capability isn't a current extraction candidate at all, and that's
+        useful information too. Not everything needs a contract on day
+        one.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/appendix/legibility-audit-framework/")}>&larr; Legibility Audit Framework</a>
+        <a href={withBase("/appendix/")}>Appendix overview &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/appendix/legibility-audit-framework.astro
+++ b/book-website/src/pages/appendix/legibility-audit-framework.astro
@@ -1,0 +1,76 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Legibility Audit Framework"
+  description="Four questions that score how safely a capability can be handed to someone who never lived through its history, human or agent. The starting point for any extraction program."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Appendix B</p>
+      <h1>Legibility Audit Framework</h1>
+
+      <p>
+        Before you can decide what to extract first, you need a way to
+        measure how illegible a capability actually is. Not a gut feeling
+        about which parts of the codebase feel scary. A score.
+      </p>
+      <p>
+        The audit runs on one diagnostic question: could you hand this
+        capability to a capable engineer who's never spoken to your team,
+        and still expect a safe change, using only what the system makes
+        available? Underneath that question sit four more specific ones.
+        Can someone tell why the capability works this way, not just what
+        it does? Can they see what was tried before and why it failed?
+        Can they understand why it calls what it calls instead of the
+        obvious alternative? Can they find every exception path driven by
+        a customer, a regulation, or something that happened three years
+        ago?
+      </p>
+      <p>
+        Score each question a full point for yes, half a point for
+        partially, zero for no. Capabilities that score low aren't a
+        judgment on the engineers who built them. They're a map of where
+        tribal knowledge is doing the most load-bearing work, and
+        therefore where an agent (or a new hire) is most likely to walk
+        into something nobody wrote down.
+      </p>
+      <p>
+        The lowest-scoring capabilities are exactly the ones that feed
+        into the next step: ranking what actually gets extracted first.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/appendix/contract-schema-reference/")}>&larr; Contract Schema Reference</a>
+        <a href={withBase("/appendix/extraction-priority-matrix/")}>Extraction Priority Matrix &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/capabilities-graph.astro
+++ b/book-website/src/pages/capabilities-graph.astro
@@ -6,7 +6,7 @@ import { withBase } from "../utils/url";
 
 <BaseLayout
   title="The Capabilities Graph"
-  description="Contracts describe one piece of logic. The capabilities graph is what happens when a whole system declares itself — legible to a new hire and an AI agent in exactly the same way."
+  description="Contracts describe one piece of logic. The capabilities graph is what happens when a whole system declares itself, legible to a new hire and an AI agent in exactly the same way."
 >
   <section class="section">
     <div class="wrap">
@@ -16,7 +16,7 @@ import { withBase } from "../utils/url";
       <p>
         A contract makes one piece of business logic legible. Chapter 4 asks
         the next question: what happens when every piece is? The answer is
-        the capabilities graph &mdash; a map of every capability in a
+        the capabilities graph, a map of every capability in a
         system, its dependencies, its owner, and the contract that governs
         it.
       </p>
@@ -30,7 +30,7 @@ import { withBase } from "../utils/url";
         already have.
       </p>
       <p>
-        The result isn't a diagram for a slide deck &mdash; it's a structure
+        The result isn't a diagram for a slide deck. It's a structure
         a new hire can read in twenty minutes instead of losing two days to,
         and a structure a coding agent can navigate instead of guess at. The
         chapter walks through what a capability is, how to draw its
@@ -40,8 +40,8 @@ import { withBase } from "../utils/url";
       <BuyLinks />
 
       <nav class="chapter-nav" aria-label="Chapter navigation">
-        <a href={withBase("/contracts/")}>&larr; Chapter 3 &mdash; Contracts Are the Answer</a>
-        <a href={withBase("/extraction-over-refactoring/")}>Chapter 5 &mdash; Extraction Over Refactoring &rarr;</a>
+        <a href={withBase("/contracts/")}>&larr; Chapter 3: Contracts Are the Answer</a>
+        <a href={withBase("/extraction-over-refactoring/")}>Chapter 5: Extraction Over Refactoring &rarr;</a>
       </nav>
     </div>
   </section>

--- a/book-website/src/pages/company-that-gets-there-first.astro
+++ b/book-website/src/pages/company-that-gets-there-first.astro
@@ -1,0 +1,78 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="The Company That Gets There First"
+  description="Most companies deploying agents right now are getting faster and calling it winning. Chapter 12 explains why velocity isn't the advantage, and what actually compounds instead."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Chapter 12 &middot; Part III: The Transformation</p>
+      <h1>The Company That Gets There First</h1>
+
+      <p>
+        Most companies deploying agents right now are getting faster. The
+        sprint velocity is up, the board update has a slide about
+        AI-assisted development, and by that measure things look good.
+        What those companies aren't getting, Chapter 12 argues, is the
+        compounding structural advantage that only shows up when a system
+        gets made legible before agents are pointed at it. That's not a
+        tooling difference. It's a difference in what kind of company
+        you've decided to be, and whether you decide that on your own
+        terms or wait for a competitor who already has.
+      </p>
+      <p>
+        The chapter draws a hard line between two kinds of organizations
+        running the exact same models and the exact same agent frameworks.
+        One is getting real velocity today, and paying for it quietly with
+        senior engineers correcting agent output that violated a
+        constraint nobody declared. The other has closed that gap, and the
+        advantage doesn't stay flat. It widens with every new model
+        generation, because a more capable agent running on a system that
+        actually explains itself gets more capable in a way that an agent
+        running on inference never does.
+      </p>
+      <p>
+        It closes the book with a single diagnostic question, one worth
+        sitting with regardless of where your organization is in this
+        process: if an agent joined your team tomorrow with access to
+        everything the system makes available, and no one around to ask,
+        what could it actually do, and what would it get catastrophically
+        wrong? The distance between those two answers is what the rest of
+        the book is trying to close.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Chapter navigation">
+        <a href={withBase("/for-engineering-leaders/")}>&larr; Chapter 11: The Leadership Team</a>
+        <a href={withBase("/appendix/")}>Appendix &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/comparisons.astro
+++ b/book-website/src/pages/comparisons.astro
@@ -1,0 +1,114 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="Comparisons"
+  description="How a C-DAD contract differs from documentation, code comments, OpenAPI specs, architecture decision records, and a full rewrite. Five honest comparisons, not five reasons to throw the alternative out."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Comparisons</p>
+      <h1>Comparisons</h1>
+
+      <p>
+        Most teams that look at C-DAD are not starting from zero. They
+        already write documentation, leave comments in the code, maintain
+        an OpenAPI spec, keep a folder of architecture decision records, or
+        are eyeing a rewrite as the fix for a system nobody trusts anymore.
+        The question is never whether a contract is better than nothing.
+        It's whether a contract does something those existing artifacts
+        don't.
+      </p>
+      <p>
+        This section works through five comparisons on their own terms.
+        None of them exist to declare a winner. Documentation, comments,
+        OpenAPI, and ADRs all solve real problems, and a contract doesn't
+        replace any of them wholesale. What follows is where each one
+        falls short for the specific job a contract is built to do: giving
+        an agent, or a new engineer, enough to act safely without tracking
+        down someone who remembers why.
+      </p>
+
+      <ul class="cluster-list">
+        <li>
+          <a href={withBase("/comparisons/c-dad-vs-documentation/")}>C-DAD vs. Documentation</a>
+          <p>Documentation is prose for humans to interpret. A contract is structured enough for an agent to act on directly.</p>
+        </li>
+        <li>
+          <a href={withBase("/comparisons/c-dad-vs-code-comments/")}>C-DAD vs. Code Comments</a>
+          <p>Comments live inline and drift with the code around them. A contract is a separate artifact that gets checked, not just read.</p>
+        </li>
+        <li>
+          <a href={withBase("/comparisons/c-dad-vs-openapi/")}>C-DAD vs. OpenAPI</a>
+          <p>OpenAPI describes the shape of a request. A contract describes why the rule inside it exists.</p>
+        </li>
+        <li>
+          <a href={withBase("/comparisons/c-dad-vs-adrs/")}>C-DAD vs. Architecture Decision Records</a>
+          <p>An ADR records a decision at the moment it was made. A contract stays validated against the system as it runs today.</p>
+        </li>
+        <li>
+          <a href={withBase("/comparisons/c-dad-vs-full-rewrite/")}>C-DAD vs. A Full Rewrite</a>
+          <p>A rewrite spends months producing cleaner code that still can't explain itself. Extraction fixes legibility one capability at a time.</p>
+        </li>
+      </ul>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/glossary/")}>&larr; Glossary</a>
+        <a href={withBase("/use-cases/")}>Use Cases &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .cluster-list {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 1.25rem;
+    margin: 2rem 0;
+  }
+
+  .cluster-list a {
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: var(--border);
+    text-underline-offset: 0.15em;
+  }
+
+  .cluster-list a:hover {
+    color: var(--coral);
+    text-decoration-color: currentColor;
+  }
+
+  .cluster-list p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/comparisons/c-dad-vs-adrs.astro
+++ b/book-website/src/pages/comparisons/c-dad-vs-adrs.astro
@@ -1,0 +1,88 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="C-DAD vs. Architecture Decision Records"
+  description="ADRs and contracts are close in spirit: both record a decision and the reasoning behind it. The difference is what happens after the decision, whether the record stays current and whether a machine can act on it."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Comparisons</p>
+      <h1>C-DAD vs. Architecture Decision Records</h1>
+
+      <p>
+        Of everything on this list, an ADR is the closest relative a
+        contract has. Teams that already write ADRs are usually already
+        doing the hard part: sitting down and writing out why a decision
+        was made, what alternatives got considered, what tradeoff got
+        accepted. That habit is genuinely good practice, and a lot of what
+        makes a contract useful is the same instinct pointed at a slightly
+        different target.
+      </p>
+      <p>
+        The difference shows up after the decision gets made. An ADR is a
+        point-in-time record. It captures the reasoning as of the day
+        someone wrote it, gets merged, and then in most teams' experience
+        sits untouched even after the decision it describes gets partially
+        reversed or quietly superseded by a later one. Nothing forces
+        anyone to go back and update an old ADR when a newer one changes
+        the underlying assumption, so a reader trying to understand the
+        current state has to read the whole history and guess which parts
+        are still true.
+      </p>
+      <p>
+        A contract is written to stay current against the system as it
+        actually runs, not just the day it was written. <code>cdad validate</code>
+        checks it against versioning rules and generated-artifact
+        consistency, so a contract that's fallen out of sync with the
+        capability it describes gets caught rather than quietly trusted.
+        And an ADR is written for a historian, someone trying to
+        understand how the system got to where it is. A contract is
+        written for someone making a change today, an agent or an engineer
+        who needs to know what's true right now, not the full sequence of
+        decisions that got there.
+      </p>
+      <p>
+        One anti-pattern makes the gap concrete: recording that an
+        incident happened without capturing the constraint it created. An
+        ADR that notes a database choice from years back, and never gets
+        revisited, is exactly the kind of record that looks thorough and
+        turns out to be dead weight. A contract's history section is meant
+        to hold the lesson, the actual constraint that future work has to
+        respect, not just a log of what happened once.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/comparisons/c-dad-vs-openapi/")}>&larr; C-DAD vs. OpenAPI</a>
+        <a href={withBase("/comparisons/c-dad-vs-full-rewrite/")}>C-DAD vs. A Full Rewrite &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/comparisons/c-dad-vs-code-comments.astro
+++ b/book-website/src/pages/comparisons/c-dad-vs-code-comments.astro
@@ -1,0 +1,86 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="C-DAD vs. Code Comments"
+  description="A good comment explains intent at the moment someone writes it. Nothing keeps that comment honest six refactors later. A contract is a separate artifact built to be checked, not just read in passing."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Comparisons</p>
+      <h1>C-DAD vs. Code Comments</h1>
+
+      <p>
+        A comment is the cheapest way to leave a note for the next person,
+        and plenty of comments earn their keep. The problem was never that
+        comments are worthless. It's that a comment lives inside the exact
+        code it describes, and code changes for reasons that have nothing
+        to do with keeping the comment true.
+      </p>
+      <p>
+        Take an anti-pattern that shows up constantly in early drafts of a
+        contract, before anyone's cleaned it up: a description that says
+        something like "retries using exponential backoff until the
+        gateway responds." That sentence describes an implementation
+        detail, not a guarantee. Six months later someone swaps the
+        backoff strategy for something smarter, the comment stays exactly
+        where it was, and now it's actively wrong instead of merely stale.
+        A better version, "retries only after the upstream system has
+        confirmed the original request is safe to repeat," survives that
+        refactor because it describes the behavior that has to stay true,
+        not the mechanism that happens to implement it today.
+      </p>
+      <p>
+        That's the structural problem with comments as a source of truth.
+        Nothing forces them to change when the code around them does, and
+        nothing flags it when they don't. A contract is deliberately built
+        as a separate, versioned artifact instead of being embedded in the
+        function it describes, and <code>cdad validate</code> checks it
+        against versioning rules and generated-artifact consistency before
+        it can drift too far from reality. It's a small difference in
+        location with a large difference in outcome.
+      </p>
+      <p>
+        Comments still matter for the small, local "why did I write it
+        this way" notes that don't rise to the level of a capability's
+        behavior. A contract isn't trying to compete there. What it's
+        built for is the higher-stakes question a comment was never
+        designed to answer reliably: can someone who's never touched this
+        code make a safe change to it, months or years after the person
+        who wrote the comment has moved on.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/comparisons/c-dad-vs-documentation/")}>&larr; C-DAD vs. Documentation</a>
+        <a href={withBase("/comparisons/c-dad-vs-openapi/")}>C-DAD vs. OpenAPI &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/comparisons/c-dad-vs-documentation.astro
+++ b/book-website/src/pages/comparisons/c-dad-vs-documentation.astro
@@ -1,0 +1,87 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="C-DAD vs. Documentation"
+  description="Documentation and contracts aren't competitors. One is prose written for a person to interpret, the other is structured enough for an agent to act on without a human translating first."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Comparisons</p>
+      <h1>C-DAD vs. Documentation</h1>
+
+      <p>
+        Every team building software already has documentation. READMEs,
+        wikis, onboarding guides, runbooks pinned in a Slack channel that
+        everyone means to migrate somewhere better. None of that goes away
+        when you adopt C-DAD, and nothing about a contract argues it
+        should. The comparison here isn't about which artifact is more
+        thorough. It's about what each one is actually built to do.
+      </p>
+      <p>
+        Documentation is written for a person. Even the best-maintained
+        wiki page assumes a reader who can hold ambiguity, notice when a
+        sentence is out of date, and fill in the gap between what's
+        written and what the system actually does today. That's a
+        reasonable assumption when the reader is a human with judgment and
+        the patience to ask a colleague when something doesn't add up.
+        It's a much worse assumption when the reader is an agent that has
+        to decide, on its own, whether a paragraph written two reorgs ago
+        is still true.
+      </p>
+      <p>
+        A contract is built around a narrower promise. It states what a
+        capability does, what it needs, what it explicitly does not do,
+        and it gets checked by <code>cdad validate</code> so the gap
+        between the artifact and the running system can't quietly widen
+        the way it can in a wiki. That structure is also what lets an
+        agent act on it directly, no person standing between the document
+        and the decision, translating intent into something machine-usable
+        on the fly.
+      </p>
+      <p>
+        None of this makes documentation obsolete. A contract has no
+        interest in replacing your architecture overview or your
+        onboarding guide, and trying to force every kind of knowledge into
+        contract form would just produce a worse version of both. C-DAD
+        targets a specific and narrower slice: the capabilities where
+        tribal knowledge is doing the load-bearing work, where the real
+        behavior lives in someone's head and not in anything a new hire or
+        an agent could find and trust. That's the gap documentation was
+        never really built to close.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/comparisons/")}>&larr; Comparisons</a>
+        <a href={withBase("/comparisons/c-dad-vs-code-comments/")}>C-DAD vs. Code Comments &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/comparisons/c-dad-vs-full-rewrite.astro
+++ b/book-website/src/pages/comparisons/c-dad-vs-full-rewrite.astro
@@ -1,0 +1,93 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="C-DAD vs. A Full Rewrite"
+  description="A full rewrite is the instinctive fix for a legacy system nobody trusts. It's also months of senior engineering time spent producing cleaner code that still can't explain itself. Extraction is the alternative."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Comparisons</p>
+      <h1>C-DAD vs. A Full Rewrite</h1>
+
+      <p>
+        At some point, every team staring at an old, tangled system has
+        the same conversation: what if we just rewrote it. New framework,
+        new patterns, a clean slate free of the workarounds that
+        accumulated over a decade of shipping under deadline. It's a
+        tempting plan, and it's not an unreasonable one. Sometimes a
+        system really is beyond salvaging and a rewrite is the honest
+        answer.
+      </p>
+      <p>
+        The trap is more specific than "rewrites are bad," which isn't
+        true. It's that a rewrite gets sold as a fix for the wrong
+        problem. Teams reach for it once they notice a system has become
+        unnavigable, expecting that cleaner code will also make the system
+        legible. It usually doesn't. A rewrite consumes an organization's
+        most senior engineers for months and produces better names, tidier
+        services, a codebase a new hire can read without wincing. What it
+        doesn't produce is a system that declares what it knows about
+        itself. Point an agent at the freshly rewritten service, and it
+        runs into the same wall it hit before the project started, because
+        legibility comes from what's declared, not from how clean the code
+        reads.
+      </p>
+      <p>
+        Extraction takes a narrower, slower-looking path that pays off
+        faster in practice: pull one capability out, contract it properly,
+        leave the rest of the legacy system alone until its turn comes.
+        <code>cdad check</code> gives you a baseline score for where the
+        legibility gaps actually are. <code>cdad roadmap</code> takes that
+        report and ranks which capabilities are worth extracting first,
+        based on how critical and how frequently touched they are.
+        <code>cdad init</code> scaffolds the contract for whichever one
+        comes up top. None of it requires freezing feature work for a
+        quarter while the rewrite catches up to where the old system
+        already was.
+      </p>
+      <p>
+        The honest tradeoff: a rewrite, if it succeeds, gives you a system
+        that's uniformly clean. Extraction gives you a system that's
+        unevenly legible for a while, some capabilities contracted and
+        safe to hand to an agent, others still exactly as opaque as they
+        were yesterday. But extraction produces value on the first
+        capability you finish, not on the day the whole project ships, and
+        it's the approach that actually targets the problem instead of
+        hoping cleaner code solves it as a side effect.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/comparisons/c-dad-vs-adrs/")}>&larr; C-DAD vs. Architecture Decision Records</a>
+        <a href={withBase("/comparisons/")}>Comparisons &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/comparisons/c-dad-vs-openapi.astro
+++ b/book-website/src/pages/comparisons/c-dad-vs-openapi.astro
@@ -1,0 +1,85 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="C-DAD vs. OpenAPI"
+  description="OpenAPI is a real and useful artifact for describing what a request and response look like. It was never designed to say why a business rule exists, and a contract fills exactly that gap."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Comparisons</p>
+      <h1>C-DAD vs. OpenAPI</h1>
+
+      <p>
+        OpenAPI does its job well, and this comparison isn't an argument
+        for dropping it. If you need to know the shape of a request, the
+        fields a response returns, or the status codes an endpoint can
+        hand back, an OpenAPI document is the right place to look, and
+        generating client code or validating a payload against it is
+        exactly what it was designed for.
+      </p>
+      <p>
+        What it was never designed to answer is why. An OpenAPI spec can
+        tell you that a discount field accepts a value between zero and
+        thirty percent. It can't tell you that the thirty percent ceiling
+        exists because of a contractual obligation to a specific partner
+        tier, or that raising it silently breaks a downstream
+        reconciliation job that assumes the old maximum. That information
+        usually lives nowhere written down at all, which is exactly the
+        gap that causes trouble once an agent starts proposing changes to
+        the field on its own.
+      </p>
+      <p>
+        A contract is behavioral and intent-focused where OpenAPI is
+        structural. It captures non-goals, the constraints a change would
+        violate, and the history that explains why the current rule exists
+        instead of the more obvious alternative someone probably tried
+        first. That's a different axis entirely from request and response
+        shape, which is why the two are complementary rather than
+        competing. A capability can reference its OpenAPI schema for the
+        wire format while the contract carries the reasoning that schema
+        was never built to hold.
+      </p>
+      <p>
+        If your team already maintains solid OpenAPI documentation, keep
+        it. C-DAD isn't asking you to replace a working spec with a
+        contract that also tries to describe field types and response
+        codes. It's pointing at the layer above that, the layer OpenAPI
+        was never scoped to cover, where the actual risk of an agent
+        making an unsafe change tends to live.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/comparisons/c-dad-vs-code-comments/")}>&larr; C-DAD vs. Code Comments</a>
+        <a href={withBase("/comparisons/c-dad-vs-adrs/")}>C-DAD vs. Architecture Decision Records &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/contact.astro
+++ b/book-website/src/pages/contact.astro
@@ -14,7 +14,7 @@ const contactEmail = "hello@example.com";
       <p class="eyebrow">Get in touch</p>
       <h1>Contact</h1>
       <p>
-        Press, speaking, or general questions about the book &mdash; reach out
+        Press, speaking, or general questions about the book: reach out
         directly.
       </p>
       <p>

--- a/book-website/src/pages/contract-lifecycle.astro
+++ b/book-website/src/pages/contract-lifecycle.astro
@@ -1,0 +1,75 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="The Contract Lifecycle"
+  description="Writing a contract once is easy. Keeping it true as the system changes is the actual work. Chapter 6 lays out the technical model for a system that stays legible to AI agents over time."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Chapter 6 &middot; Part II: The Architecture</p>
+      <h1>The Contract Lifecycle</h1>
+
+      <p>
+        A contract that's accurate on the day it's written and stale six
+        months later isn't a fix. It's a trap with better packaging than a
+        wiki page, because now everyone trusts it. Chapter 6 is about the
+        part of this model that doesn't show up in a diagram: what keeps a
+        contract true as the capability underneath it keeps changing.
+      </p>
+      <p>
+        The chapter follows a developer who's new enough to the team that
+        she's never touched the old, undocumented version of the system.
+        She opens a capability's contract before making a change, the way
+        you'd check a map before a trip. What she finds isn't just a
+        description. It's a business rule stated in one sentence, the
+        dependencies it relies on, the things it deliberately doesn't do,
+        and a constraint history that explains why a limit got lowered
+        three years ago. She hands the task to an agent. It comes back with
+        a flagged dependency the contract didn't mention yet. It was right
+        to flag it. She updates the contract before approving the change.
+        Eleven minutes, start to finish.
+      </p>
+      <p>
+        That's the lifecycle working as intended: not a document that gets
+        written once and forgotten, but something that gets checked, used,
+        and corrected as part of the normal flow of work. The chapter
+        covers what makes that possible technically, what breaks it, and
+        why a contract nobody's pipeline enforces is really just
+        documentation wearing a costume.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Chapter navigation">
+        <a href={withBase("/extraction-over-refactoring/")}>&larr; Chapter 5: Extraction Over Refactoring</a>
+        <a href={withBase("/for-architects/")}>Chapter 7: The Architect &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/contracts.astro
+++ b/book-website/src/pages/contracts.astro
@@ -18,8 +18,8 @@ import { withBase } from "../utils/url";
         write it down. More documentation. A better wiki. Clearer onboarding
         docs. Chapter 3 argues that every one of these responses is a
         genuine attempt that treats the symptom without touching the
-        underlying condition &mdash; because a wiki page describes a system;
-        it doesn't let an agent act on it.
+        underlying condition, because a wiki page describes a system.
+        It doesn't let an agent act on it.
       </p>
       <p>
         A contract is different in kind, not just in polish: a structured,
@@ -30,7 +30,7 @@ import { withBase } from "../utils/url";
       </p>
       <p>
         This is the chapter that defines what a contract actually has to
-        capture &mdash; not a template to fill in casually, but the minimum
+        capture, not a template to fill in casually, but the minimum
         a system needs to declare about itself before an agent (or a new
         hire) can act on it safely. It's the hinge point of the book:
         everything before it names the problem, everything after it is how
@@ -40,8 +40,8 @@ import { withBase } from "../utils/url";
       <BuyLinks />
 
       <nav class="chapter-nav" aria-label="Chapter navigation">
-        <a href={withBase("/tribal-knowledge/")}>&larr; Chapter 2 &mdash; Tribal Knowledge Is the Bottleneck</a>
-        <a href={withBase("/capabilities-graph/")}>Chapter 4 &mdash; The Capabilities Graph &rarr;</a>
+        <a href={withBase("/tribal-knowledge/")}>&larr; Chapter 2: Tribal Knowledge Is the Bottleneck</a>
+        <a href={withBase("/capabilities-graph/")}>Chapter 4: The Capabilities Graph &rarr;</a>
       </nav>
     </div>
   </section>

--- a/book-website/src/pages/core-model.astro
+++ b/book-website/src/pages/core-model.astro
@@ -1,0 +1,125 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="The Core Model"
+  description="Legibility, capability, contract, capability graph. Four terms the toolkit uses precisely, defined here at the depth a glossary entry can't reach."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Core Model</p>
+      <h1>The Core Model</h1>
+
+      <p>
+        The toolkit rests on four concepts, and the docs define each of
+        them in a single sentence: legibility, capability, contract,
+        capability graph. That's the right length for a reference card.
+        It's the wrong length for actually understanding how the pieces
+        fit together, why the order matters, or what goes wrong when a
+        team applies one of them halfway. This cluster of pages exists to
+        close that gap, one concept at a time, at the depth the book
+        gives them across Chapters 2 through 6.
+      </p>
+      <p>
+        Start with legibility, because it's the diagnostic the rest of
+        the model responds to. From there, capability defines the unit
+        being diagnosed, and contract defines what you write down once
+        you've decided a capability is worth the effort. The capability
+        graph is what you get when contracts accumulate across a whole
+        system. The last three pages are more operational: the minimum
+        fields a contract actually needs, the specific ways contracts
+        drift when nobody's watching, and the arc a capability travels
+        from invisible logic to something a contract governs.
+      </p>
+
+      <ul class="cluster-list">
+        <li>
+          <a href={withBase("/core-model/legibility/")}>Legibility</a>
+          <p>What the term means precisely, the four questions used to score it, and how `cdad check` turns that scoring into a number.</p>
+        </li>
+        <li>
+          <a href={withBase("/core-model/capability/")}>Capability</a>
+          <p>The business-facing unit the whole model is built around, and why it cuts a system along different lines than a service boundary does.</p>
+        </li>
+        <li>
+          <a href={withBase("/core-model/contract/")}>Contract</a>
+          <p>What a contract actually has to declare before an agent, or a new hire, can act on a capability without guessing.</p>
+        </li>
+        <li>
+          <a href={withBase("/core-model/capability-graph/")}>Capability Graph</a>
+          <p>The dependency map that emerges once contracts accumulate, and how humans and agents read it differently.</p>
+        </li>
+        <li>
+          <a href={withBase("/core-model/minimum-viable-contract/")}>Minimum Viable Contract</a>
+          <p>The exact fields a contract needs to be useful, no more and no less, field by field.</p>
+        </li>
+        <li>
+          <a href={withBase("/core-model/contract-anti-patterns/")}>Contract Anti-Patterns</a>
+          <p>Five specific, recognizable ways a contract drifts away from what it's supposed to do, with real examples.</p>
+        </li>
+        <li>
+          <a href={withBase("/core-model/capability-lifecycle-states/")}>Capability Lifecycle States</a>
+          <p>How a capability moves from invisible logic nobody's named to a node the graph and an agent can both trust.</p>
+        </li>
+      </ul>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/why-c-dad/from-documentation-to-contracts/")}>&larr; From documentation to contracts</a>
+        <a href={withBase("/how-c-dad-works/")}>How C-DAD works &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .cluster-list {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 1.25rem;
+    margin: 2rem 0;
+  }
+
+  .cluster-list a {
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: var(--border);
+    text-underline-offset: 0.15em;
+  }
+
+  .cluster-list a:hover {
+    color: var(--coral);
+    text-decoration-color: currentColor;
+  }
+
+  .cluster-list p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/core-model/capability-graph.astro
+++ b/book-website/src/pages/core-model/capability-graph.astro
@@ -1,0 +1,145 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Capability Graph"
+  description="The capability graph is the directed dependency map of every contract in a repo. It shows how capabilities connect, where change can propagate, and what still needs extraction work."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Core Model</p>
+      <h1>Capability Graph</h1>
+
+      <p>
+        The capability graph is the directed dependency map of all
+        contracts in a repository. It shows how capabilities connect to
+        each other, where a change in one is likely to propagate into
+        another, and which areas of the system still haven't been
+        extracted at all. A contract makes one piece of business logic
+        legible. The graph is what you get once enough of those
+        contracts exist that the connections between them become
+        visible instead of assumed.
+      </p>
+      <p>
+        The graph isn't hand-drawn or maintained separately from the
+        contracts it represents. It's generated. `cdad graph` reads
+        every contract in the repo and renders the result three ways: a
+        Mermaid diagram for humans to look at, a Markdown summary, and a
+        JSON adjacency list that's meant to be the stable, machine-
+        consumable format. That JSON output is deliberately treated as
+        the one to depend on if you're feeding graph state into other
+        tooling. Mermaid is for a person scanning a diagram. JSON is for
+        an agent that needs to walk the dependency chain programmatically
+        without parsing a picture.
+      </p>
+      <p>
+        On disk, that render lands as three files: `cdad-graph.mmd` for
+        the Mermaid source, `cdad-graph.json` for the adjacency list,
+        and `cdad-graph.md` for a readable summary, and each output can
+        be switched off independently with `--no-mermaid` or `--no-json`
+        if a workflow only needs one of them. The Markdown summary
+        reports coverage in plain terms too, something close to "N
+        capabilities contracted across M domains," which is a fast way
+        to answer "how much of this system actually declares itself"
+        without opening the diagram at all.
+      </p>
+      <p>
+        The graph can be scoped rather than rendered whole every time.
+        `--capability` narrows it to one node and its neighbors,
+        `--domain` narrows it to a business area, and `--state` filters
+        by lifecycle state so you can, for instance, look only at
+        capabilities still marked draft. That scoping matters in a
+        codebase of any real size, because a full-repo graph gets
+        visually noisy fast, and most questions people actually ask are
+        local: what does this one capability depend on, and what depends
+        on it.
+      </p>
+      <p>
+        `--output` redirects where those three files land, useful if a
+        team wants graph artifacts checked into a docs folder rather
+        than sitting at the repo root, and it's the kind of small option
+        that matters more than it sounds like once graph generation
+        becomes a step in CI rather than something someone runs by hand
+        occasionally. A graph that only gets regenerated when a person
+        remembers to is a graph that's usually a little stale, and a
+        stale graph is worse than no graph, because it looks
+        authoritative right up until someone trusts an edge that no
+        longer exists.
+      </p>
+      <p>
+        "Where change can propagate" is the practical payoff of drawing
+        the edges explicitly. If `payment/retry` depends on
+        `payment/gateway-status`, that dependency shows up as an edge in
+        the graph, not as something a reviewer has to reconstruct from
+        memory or from reading both pieces of code side by side. Change
+        the gateway-status capability and the graph tells you, before
+        you ship, what else is downstream of that change. That's the
+        difference between a review that catches a breaking change and
+        one that catches it in production three weeks later.
+      </p>
+      <p>
+        The graph is also a coverage map, whether or not that was the
+        intent behind checking it. A capability with no contract simply
+        doesn't appear as a node, which means gaps in extraction work
+        show up as literal blank space rather than something you'd have
+        to go looking for. Running `cdad check` again after a round of
+        extraction, the last stage in the toolkit's recommended workflow,
+        is partly about watching that blank space shrink over time as
+        more of the system actually declares itself.
+      </p>
+      <p>
+        The graph also inherits the three properties Chapter 4 assigns to
+        a capability itself. Every node is headless, so the graph
+        doesn't care whether a capability backs a web app or an agent
+        calling it directly. Every node is portable, so an edge means
+        the same thing regardless of which service happens to host
+        either end of it. And every node is contract-defined, which is
+        the property that makes the whole graph trustworthy in the
+        first place, since an edge only exists because a contract
+        declared the dependency, not because someone eyeballed the code
+        and guessed.
+      </p>
+      <p>
+        Chapter 4 frames the graph as the answer to a specific question:
+        a contract makes one piece of logic legible, so what happens
+        once every piece is? The result, per the chapter, isn't a
+        diagram built for a slide deck. It's a structure a new hire can
+        read in twenty minutes instead of losing two days to, and a
+        structure an agent can navigate directly instead of trying to
+        infer from scattered files.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/core-model/contract/")}>&larr; Contract</a>
+        <a href={withBase("/core-model/minimum-viable-contract/")}>Minimum Viable Contract &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/core-model/capability-lifecycle-states.astro
+++ b/book-website/src/pages/core-model/capability-lifecycle-states.astro
@@ -1,0 +1,148 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Capability Lifecycle States"
+  description="How a capability actually moves through a codebase: undiscovered, prioritized, extracted, and contracted, and why that arc keeps repeating instead of finishing once."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Core Model</p>
+      <h1>Capability Lifecycle States</h1>
+
+      <p>
+        There are two different things this toolkit calls a "state," and
+        it's worth separating them before going further. One is the
+        formal field on a contract itself, draft, active, deprecated, or
+        retired, covered on the Minimum Viable Contract page. The other
+        is the bigger arc a capability travels before any contract
+        exists for it at all, which is what this page is about: how a
+        piece of business logic goes from invisible to something the
+        graph and an agent can both rely on.
+      </p>
+      <p>
+        Most capabilities in a real codebase start out undiscovered.
+        They're running correctly in production, embedded inside a
+        service or a script, doing real work with no agreed-on boundary
+        and no name anyone outside the immediate team would recognize.
+        A discount calculator threaded through three modules. A payment
+        retry policy wired into the payment service alongside a dozen
+        other responsibilities. None of that is broken. It's just
+        invisible to anything that isn't a person who happens to
+        remember it's there, which is exactly the condition `cdad check`
+        exists to surface, by combining a static scan with the
+        legibility questionnaire and scoring the result.
+      </p>
+      <p>
+        It's worth sitting with how much of a codebase this first stage
+        usually covers. Undiscovered isn't a rare edge case reserved for
+        one neglected corner of a repo, in most organizations it's the
+        default condition of nearly everything, because writing a
+        contract has never been the fast path and nobody gets rewarded
+        for naming a boundary that already works fine without one. The
+        toolkit doesn't treat that as a moral failing on any team's
+        part. It treats it as the normal starting condition and builds
+        the rest of the workflow to move a system out of it gradually,
+        one capability at a time, rather than expecting a team to
+        contract everything at once.
+      </p>
+      <p>
+        Discovery alone doesn't tell you what to do first. That's the
+        job of the next stage, where `cdad roadmap` reads the check
+        report, adds two more axes, criticality and how often agents
+        would actually touch a given capability, multiplies the factors
+        together, and produces an ordered list. Not every undiscovered
+        capability needs extraction on day one. Roadmap is what turns a
+        pile of findings into a queue with an actual first item, so a
+        team isn't stuck deciding by gut feeling which of forty gaps to
+        close first.
+      </p>
+      <p>
+        Extraction is where a capability gets named and bounded for the
+        first time. `cdad init &lt;capability-id&gt;` validates that the id
+        follows the domain/subdomain/action convention and scaffolds the
+        contract triple around it. At this point the capability has an
+        identity and a boundary, but the contract fields underneath it
+        are placeholders, not yet earned answers. This is the moment
+        Chapter 5 is built around, and it's worth being precise that
+        extraction isn't the same operation as refactoring the
+        underlying code. The logic itself doesn't have to move for a
+        capability to go from undiscovered to extracted. It just has to
+        get a name, a boundary, and a scaffold.
+      </p>
+      <p>
+        Contracted is the last stage, and it's where the real work
+        happens. The placeholder fields get replaced with honest
+        answers: a description written as business intent instead of
+        implementation mechanics, non-goals that actually say something,
+        inputs and outputs carrying real constraints and guarantees,
+        open questions either resolved or left explicitly open rather
+        than papered over. `cdad validate` checks the schema, the
+        versioning, and whether the generated artifacts still match the
+        source before any of this can move to `state: active`. Once a
+        capability clears that bar, `cdad graph` renders it as a real
+        node with real edges, something other people and other agents
+        can navigate instead of merely being told exists.
+      </p>
+      <p>
+        It's worth noticing that this arc mirrors how the toolkit itself
+        got built, in three phases rather than four stages, but the same
+        underlying shape. Phase one was the foundation: repo structure,
+        schemas, templates, the pieces that have to exist before
+        anything else can earn trust. Phase two was the core workflow,
+        check, roadmap, init, validate, graph, the commands that
+        actually move a capability through undiscovered, prioritized,
+        extracted, and contracted. Phase three was polish, agent
+        configs, finished docs, the work that makes the whole thing easy
+        to hand to someone else. A capability moving through its own
+        lifecycle follows a smaller version of the same pattern: get the
+        boundary right first, then fill in the substance, then make sure
+        it's actually usable by the next person who finds it.
+      </p>
+      <p>
+        None of this is a one-way trip you take once and forget. A
+        contracted capability can slide backward if the underlying logic
+        changes and nobody updates the contract to match, which is how
+        tribal knowledge creeps back into a system that used to be
+        legible. Running `cdad check` again is literally the last stage
+        in the toolkit's recommended workflow, and it closes the loop:
+        the same command that found the undiscovered work at the start
+        is the one that tells you, later, whether the repo is actually
+        getting easier to navigate or just looks that way from the
+        outside.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/core-model/contract-anti-patterns/")}>&larr; Contract Anti-Patterns</a>
+        <a href={withBase("/core-model/")}>The core model &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/core-model/capability.astro
+++ b/book-website/src/pages/core-model/capability.astro
@@ -1,0 +1,143 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Capability"
+  description="A capability is a business-facing unit of behavior with inputs, outputs, non-goals, and a name that a contract and a graph can both reference. Here's what that actually means as a design boundary."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Core Model</p>
+      <h1>Capability</h1>
+
+      <p>
+        A capability is a business-facing unit of behavior with inputs,
+        outputs, non-goals, and a human-readable name that can be
+        referenced in contracts and in the graph. That definition is
+        short on purpose, but it's doing more work than it looks like.
+        The key phrase is business-facing. A capability isn't a class, a
+        module, or a microservice. Those are implementation choices,
+        and a team can restructure them without changing what the
+        business is actually doing. A capability is named after what it
+        does for the business: payment retry, discount calculation,
+        session login. It survives a rewrite because it describes intent,
+        not code shape.
+      </p>
+      <p>
+        Chapter 4 introduces the capability as a new atomic unit of
+        software design and gives it three properties. Headless, meaning
+        it carries no assumptions about how it gets presented, so the
+        same capability can back a web app, a batch job, or an agent
+        calling it directly. Portable, meaning it runs wherever it's
+        called from instead of being wired to one service's internals.
+        Contract-defined, meaning its boundaries and rules are declared
+        somewhere explicit rather than inferred by whoever's willing to
+        read the code closely enough. Those three properties are what
+        make a capability a stable unit to build a graph out of, instead
+        of a shape that changes every time someone refactors.
+      </p>
+      <p>
+        This is a genuinely different way to decompose a system than the
+        service boundaries most teams already have. Service boundaries
+        tend to follow deployment convenience: what's easy to scale
+        separately, what one team owns, what fits in a repo. Capability
+        boundaries follow business meaning instead. A single service can
+        host several capabilities, and a single capability can, in
+        principle, span more than one service. That mismatch is normal.
+        The capability boundary isn't trying to replace your
+        architecture. It's trying to give the business logic inside that
+        architecture a name an agent can act on.
+      </p>
+      <p>
+        Capabilities get identified with a semantic naming convention,
+        lowercase and slash-delimited, in the form
+        `domain/subdomain/action`. `payment/retry` and
+        `auth/session/login` are the examples the schema itself uses.
+        That's not a cosmetic choice. The id is what a contract
+        references, what shows up as a node in the graph, and what you
+        pass to `cdad init` when you're ready to scaffold a contract for
+        it. A capability without a stable id is hard to point an agent
+        at reliably, because there's nothing consistent to point at.
+      </p>
+      <p>
+        Granularity is the other thing that trips teams up when they
+        first start drawing these boundaries. A capability isn't a whole
+        domain, payment processing as a topic is too broad to fit
+        inputs, outputs, and one clear set of non-goals. It's also not a
+        single low-level function, a currency-rounding helper is too
+        small to carry any business intent worth declaring on its own.
+        The right size is the one that maps to a business rule someone
+        could actually explain in a sentence: retry this payment, apply
+        this discount, log this session in. If a capability needs three
+        sentences to explain what it does, it's probably two
+        capabilities wearing one name, and if it needs a whole paragraph
+        to say what it doesn't do, the non-goals are covering for a
+        boundary that was never drawn tightly enough in the first place.
+      </p>
+      <p>
+        Here's the part that trips people up early: a capability doesn't
+        get created when you write a contract for it. It usually already
+        exists, running in production, embedded somewhere in the
+        codebase, doing its job correctly with nobody having drawn a
+        boundary around it. Extraction, the subject of Chapter 5, is the
+        act of noticing that boundary and naming it. Writing the contract
+        comes after. The capability was real the whole time. It just
+        wasn't legible.
+      </p>
+      <p>
+        The `domain` segment of that id isn't decorative either. It's
+        what lets tooling group capabilities the way a business actually
+        thinks about them, `cdad graph --domain payment` scopes the
+        dependency map to one business area instead of the whole repo,
+        and the graph's own summary reports coverage domain by domain,
+        not service by service. A capability's domain and a capability's
+        deployment home can line up, but they don't have to, and when
+        they don't, that mismatch is often the first sign that a service
+        boundary was drawn for infrastructure reasons rather than
+        business ones.
+      </p>
+      <p>
+        Once a capability has a name and a boundary, it becomes the thing
+        everything else in the model attaches to. A contract declares
+        what one capability does. The graph shows how many capabilities
+        connect to each other. Get the capability boundary wrong, drawn
+        around a chunk of implementation instead of a piece of business
+        intent, and the contract you write for it will fight you the
+        whole way, because you'll be trying to describe intent for
+        something that was never scoped to have any.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/core-model/legibility/")}>&larr; Legibility</a>
+        <a href={withBase("/core-model/contract/")}>Contract &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/core-model/contract-anti-patterns.astro
+++ b/book-website/src/pages/core-model/contract-anti-patterns.astro
@@ -1,0 +1,147 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Contract Anti-Patterns"
+  description="Five specific, recognizable ways a contract drifts away from what it's supposed to do, each with a real bad example, a better rewrite, and why it matters."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Core Model</p>
+      <h1>Contract Anti-Patterns</h1>
+
+      <p>
+        A schema tells you which fields a contract needs. It doesn't
+        stop someone from filling those fields in badly. Contracts drift
+        away from their intent for a small number of specific, recurring
+        reasons, and recognizing them by name is a lot faster than
+        rediscovering each one the hard way during a review.
+      </p>
+      <p>
+        The first is writing implementation language into the
+        description. A bad description reads something like "retries
+        using exponential backoff until the gateway responds," which
+        sounds precise but is actually describing a mechanism, one that
+        might get swapped out next sprint without the business rule
+        behind it changing at all. The better version says "retries only
+        after the upstream system has confirmed the original request is
+        safe to repeat." That sentence survives a rewrite of the retry
+        logic because it isn't describing the logic, it's describing the
+        constraint the logic exists to satisfy. Contracts should declare
+        behavior and guarantees, not freeze one implementation detail
+        that's likely to change later anyway.
+      </p>
+      <p>
+        Notice what these two bad examples have in common: they both
+        read as complete sentences. Nothing about "retries using
+        exponential backoff until the gateway responds" looks
+        unfinished on the page. That's what makes implementation
+        language a slippery anti-pattern to catch in review. It doesn't
+        look broken, it looks specific, and specific often gets mistaken
+        for good. The tell isn't how the sentence reads. It's whether
+        the sentence would still be true after someone swapped the
+        retry mechanism for a different one next quarter.
+      </p>
+      <p>
+        The second is leaving `non_goals` empty because the scope feels
+        obvious to whoever's writing the contract. It rarely feels
+        obvious to the next person, and it definitely doesn't feel
+        obvious to an agent with no memory of the conversation where the
+        scope got decided. The fix is just saying it: state plainly what
+        the capability does not do, so the next change doesn't expand it
+        by accident. A blank non-goals field doesn't mean the boundary
+        doesn't exist. It means the boundary is unenforced, and review
+        of anything that crosses it turns subjective instead of being a
+        quick check against a written line.
+      </p>
+      <p>
+        The third is recording history without the lesson it produced.
+        An incident note that just says an outage happened, or that a
+        limit got changed on a certain date, tells a future reader that
+        something occurred without telling them what they're now
+        required to preserve. The better version captures the
+        constraint the incident created: not "we had an outage in
+        March" but "the retry cap must not go above this value without
+        confirming the processor's idempotency window first, because
+        raising it caused duplicate charges in March." Incident notes
+        are only useful when they carry the lesson forward, not just the
+        event.
+      </p>
+      <p>
+        The fourth is treating generated artifacts as hand-edited
+        source. A contract is a triple: `contract.yaml` as the
+        authored source, `contract.json` and `contract.md` generated
+        from it. Editing the JSON or the Markdown directly and leaving
+        the YAML untouched creates a fork nobody asked for, one file
+        says one thing and the source of truth says another. The fix is
+        procedural discipline: treat the YAML as authoritative and use
+        validation or regeneration to keep the derived files aligned,
+        every time, not just when someone remembers to.
+      </p>
+      <p>
+        The fifth is using graph output as the only place dependency
+        relationships get recorded. It's tempting to update a
+        dependency in a design doc or a Slack thread and consider it
+        done, but `cdad graph` doesn't read prose. It reads contracts.
+        If the contract's dependency data doesn't change, the graph
+        won't either, no matter how thoroughly the change got described
+        somewhere else. The better order is contract first, graph
+        second: update the contract, then regenerate the graph from it,
+        so the rendered output stays trustworthy instead of becoming
+        commentary that quietly stopped matching reality.
+      </p>
+      <p>
+        None of these five are exotic mistakes. They're the ordinary way
+        a contract degrades when it's written under deadline pressure by
+        someone who understands the capability well enough to skip
+        steps mentally. That's actually the trap: the person writing a
+        rushed contract usually does know why the retry logic works the
+        way it does, which is exactly why they don't feel the gap they
+        just left for the next reader. The five patterns are worth
+        naming because a checklist catches what expertise quietly skips
+        past.
+      </p>
+      <p>
+        `cdad validate` catches some of this automatically, mainly the
+        structural violations like a missing field or a state that
+        can't legally be active yet. It won't catch a description that's
+        technically present but written as implementation detail, or a
+        non-goal that's too vague to mean anything. That part still
+        takes a reviewer who knows what these five patterns look like on
+        sight.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/core-model/minimum-viable-contract/")}>&larr; Minimum Viable Contract</a>
+        <a href={withBase("/core-model/capability-lifecycle-states/")}>Capability Lifecycle States &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/core-model/contract.astro
+++ b/book-website/src/pages/core-model/contract.astro
@@ -1,0 +1,144 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Contract"
+  description="A contract is the machine-readable and human-readable declaration of a capability: what it does, what it needs, what it promises, and what it explicitly refuses to do."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Core Model</p>
+      <h1>Contract</h1>
+
+      <p>
+        A contract is the machine-readable and human-readable declaration
+        of a capability. It says what the capability does, what it
+        needs, what it promises, and what it explicitly does not do.
+        That last clause matters as much as the first three. Most
+        documentation describes behavior and stops there. A contract
+        also draws the edge around the behavior, on purpose, so the next
+        person, or the next agent, doesn't quietly expand scope just
+        because nothing told them not to.
+      </p>
+      <p>
+        The instinct, once tribal knowledge gets named as a problem, is
+        to write more of it down. A better wiki. Clearer onboarding
+        pages. Chapter 3 argues that this instinct, while well meaning,
+        treats a structural gap as a writing gap. A wiki page is prose,
+        built for a person to read and interpret, and interpretation is
+        precisely the step an AI agent can't reliably perform. Tell an
+        agent "retries are capped to avoid overloading the payment
+        processor during an outage" and it has to guess how that
+        sentence turns into a specific number, a specific exception, a
+        specific line it's allowed to touch. A contract removes the
+        guess by being structured instead of narrative, specific enough
+        for a human to trust and consistent enough for a machine to
+        parse without a person translating in between.
+      </p>
+      <p>
+        What a contract has to say breaks into four parts, and the
+        toolkit's schema treats each one as a distinct set of fields
+        rather than one big freeform paragraph. What the capability does
+        and why it exists, captured as business intent rather than
+        implementation detail. What it needs to run, its declared
+        inputs, each with a type and the business constraint behind it.
+        What it promises, its outputs and the guarantees attached to
+        each one. And what it explicitly refuses to do, its non-goals,
+        stated as plain declarative sentences instead of left implicit.
+        The Minimum Viable Contract page walks through every field this
+        produces.
+      </p>
+      <p>
+        That four-part shape is the floor, not the ceiling. The minimum
+        viable contract, walked through field by field on its own page,
+        covers exactly what's required to make a capability legible at
+        all. An extended contract layers on more: named dependencies on
+        other capabilities, performance thresholds, how specific error
+        conditions should behave, which trust zone the capability
+        operates in, rate limits, constraints inherited from a policy
+        set somewhere higher up, and a constraint history that preserves
+        the incidents that shaped the current behavior. Most teams don't
+        need the extended fields for their first few contracts. They
+        become worth the effort once a capability sits somewhere risky
+        enough that the minimum fields stop capturing everything a
+        reviewer needs to trust it.
+      </p>
+      <p>
+        There's a writing rule underneath every field in the schema, and
+        it's worth stating plainly because it's easy to violate without
+        noticing: write intent, guarantees, and boundaries in plain
+        language, and if a field starts describing retries, caches,
+        queues, polling, or backoff just because that happens to be how
+        the capability is currently built, rewrite it toward the
+        business rule that actually justifies the behavior. The test is
+        whether a practitioner could understand the capability from the
+        contract alone, without opening the code to reverse-engineer
+        what the prose was dancing around. A contract that restates
+        method names and internal optimization choices has failed at
+        this even if every field is technically filled in.
+      </p>
+      <p>
+        A contract isn't one file. It's a triple: `contract.yaml` as the
+        human-authored source of truth, plus `contract.json` and
+        `contract.md` generated from it for machine consumption and
+        readable rendering. That split only works if the discipline
+        holds, the YAML gets edited and the other two get regenerated
+        from it, not the other way around. Editing the generated
+        Markdown by hand and leaving the YAML stale is one of the most
+        common ways a contract quietly stops being true, covered in
+        detail on the anti-patterns page.
+      </p>
+      <p>
+        Contracts don't stay static once written. Each one carries a
+        `state`, draft, active, deprecated, or retired, and a contract
+        can't move to active while its open questions are still
+        unresolved. `cdad validate` is what enforces this before a
+        change lands: it checks the schema, the versioning rules, and
+        whether the generated artifacts still match the source YAML, and
+        it can be wired into a pre-commit hook so drift gets caught
+        before it merges rather than after someone's already trusted a
+        stale answer.
+      </p>
+      <p>
+        This is the hinge point of the book's argument, not incidentally
+        Chapter 3's position in the table of contents. Everything before
+        it names the problem: tribal knowledge, illegible systems, agents
+        that can't safely act without a person translating first.
+        Everything after it is what you build once you accept that a
+        contract, not a better wiki, is the actual fix.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/core-model/capability/")}>&larr; Capability</a>
+        <a href={withBase("/core-model/capability-graph/")}>Capability Graph &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/core-model/legibility.astro
+++ b/book-website/src/pages/core-model/legibility.astro
@@ -1,0 +1,146 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Legibility"
+  description="Legibility is whether a capable engineer or agent can understand why a capability behaves the way it does, without someone explaining the backstory out loud. Here's how the toolkit scores it."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Core Model</p>
+      <h1>Legibility</h1>
+
+      <p>
+        Legibility is the concept the rest of the toolkit gets built on
+        top of. The precise definition: the degree to which a capable
+        engineer or agent can understand why a capability behaves the way
+        it does, without relying on someone who remembers the backstory.
+        It's not a synonym for documentation coverage. A repository can
+        carry exhaustive comments and still be illegible if none of them
+        explain the reasoning behind a decision, and a repository can be
+        sparse on comments and still score well if the reasoning that
+        actually matters lives somewhere a reader can find it.
+      </p>
+      <p>
+        The distinction legibility hinges on is why versus what. Reading
+        a function usually tells you what it does. That part's rarely
+        the hard problem, assuming the code isn't actively hostile to
+        reading. What the code can't tell you is why it does that
+        instead of the more obvious alternative, why a limit sits at the
+        value it sits at, why one path retries and a nearly identical
+        path doesn't. That reasoning either lives in something built to
+        carry it or it lives in a person's memory, and people leave
+        teams. Chapter 2 of the book spends its length on exactly this
+        gap: an engineer walking a new hire through constraints that
+        exist nowhere except in her own head, and the moment that
+        knowledge transfer becomes the actual bottleneck to shipping
+        anything with confidence.
+      </p>
+      <p>
+        The toolkit measures legibility with four diagnostic questions,
+        covered in full in the Legibility Audit Framework appendix. Can
+        someone tell why the capability works this way, not only what it
+        does? Can they see what was tried before and why it failed? Can
+        they understand why it calls what it calls instead of the
+        obvious alternative? Can they find every exception path driven
+        by a customer, a regulation, or an incident from three years
+        back? Each question is scored a full point for yes, half a point
+        for partially, and zero for no. The resulting score isn't a
+        judgment on whoever built the capability. It's a map of where
+        tribal knowledge is doing the heaviest lifting.
+      </p>
+      <p>
+        The diagnostic question underneath all four of those is the same
+        one: could you hand this capability to a capable engineer who's
+        never spoken to your team, and still expect a safe change, using
+        only what the system makes available? That phrasing is doing
+        something specific. It doesn't say "a senior engineer on this
+        team" or "someone who's read the wiki." It says a capable
+        engineer with no history here, because that's the actual
+        condition an AI agent operates under on every single task. An
+        agent can read every file in a repository in seconds, but it
+        can't sit in on the hallway conversation where someone explains
+        why a limit is set where it's set. Legibility is what determines
+        whether that gap matters.
+      </p>
+      <p>
+        In practice, this scoring runs the first time you use the CLI.
+        `cdad check` combines a static scan of the repository with that
+        four-question interview, asked against up to five capabilities
+        by default and tunable with `--capabilities`. It returns a
+        single agent-readiness score from 0 to 10 along with a band that
+        tells you roughly where the repo stands, and it writes the full
+        result to `cdad-report.md` in a format structured enough that
+        `cdad roadmap` can read it back in and use it to decide what gets
+        extracted first. The two halves of the check, static scan and
+        questionnaire, are independent enough that either one can be
+        skipped on its own: `--skip-scan` runs the questionnaire alone,
+        `--skip-questions` runs the static analysis alone. That's a
+        useful thing to know if you're re-running check often and only
+        want a quick signal from one side of it.
+      </p>
+      <p>
+        It's worth being precise about what a legibility score isn't.
+        It's not a code quality metric. A codebase can be clean,
+        well-tested, and consistently styled, and still be illegible if
+        the reasoning behind its harder decisions was never captured
+        anywhere durable. It's also not a one-time badge. A capability
+        that scores well today can drift back down if its contract goes
+        stale and nobody notices, which is a large part of why `cdad
+        check` is meant to run again and again as the repo changes, not
+        once at kickoff and never again.
+      </p>
+      <p>
+        There's also a difference between legibility and comfort that's
+        easy to blur. A senior engineer who's worked on a system for
+        years might feel completely at home in code that would score
+        badly on every one of the four questions, because their comfort
+        is coming from memory, not from anything the system itself
+        makes available. Legibility asks a harder question than "does
+        this feel navigable to the people who already know it." It asks
+        whether the knowledge those people are carrying around in their
+        heads has actually made it into something durable enough for
+        the next person, or the next agent, to find on their own.
+      </p>
+      <p>
+        Legibility is the diagnostic. The rest of the core model exists
+        to respond to what it finds. Once you know which parts of a
+        system are illegible, and roughly why, the next question is what
+        unit of that system you're actually trying to fix, which is
+        where the idea of a capability comes in.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/core-model/")}>&larr; The core model</a>
+        <a href={withBase("/core-model/capability/")}>Capability &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/core-model/minimum-viable-contract.astro
+++ b/book-website/src/pages/core-model/minimum-viable-contract.astro
@@ -1,0 +1,153 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Minimum Viable Contract"
+  description="The eleven fields a contract needs before it's actually useful, from id and state through non-goals and open questions, and why each one earns its place."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Core Model</p>
+      <h1>Minimum Viable Contract</h1>
+
+      <p>
+        How much does a contract have to say before it's actually
+        useful? The toolkit answers that with a schema, not a vibe.
+        Eleven fields are required: `id`, `version`, `owner`, `state`,
+        `name`, `description`, `inputs`, `outputs`, `non_goals`,
+        `use_cases`, and `open_questions`. Nothing below that floor
+        counts as a real contract, and the point of naming the floor
+        explicitly is that a team can stop guessing whether they've
+        written enough.
+      </p>
+      <p>
+        Four fields establish identity. `id` is the semantic name in
+        `domain/subdomain/action` form, lowercase and slash-delimited,
+        like `payment/retry`. `version` follows standard semantic
+        versioning, major for breaking changes, minor for
+        backward-compatible additions, patch for corrections to the text
+        itself. `owner` names the team or person accountable for keeping
+        the contract true. `state` tracks where the contract sits in its
+        own lifecycle: draft, active, deprecated, or retired, and a
+        contract can't sit at active while `open_questions` still holds
+        unresolved items. That rule alone stops a team from marking
+        something authoritative before it's actually settled.
+      </p>
+      <p>
+        Two fields carry the description. `name` is the plain-English
+        label a human recognizes. `description` is where discipline
+        matters most, because it's supposed to capture business intent,
+        not implementation mechanics. The schema's own guidance draws
+        the line with an example: wrong is "retries using exponential
+        backoff," correct is "retries only after confirming the upstream
+        processor has not yet received the request, because this
+        processor does not honor idempotency keys until after processing
+        completes." One describes a mechanism that might change next
+        quarter. The other describes a business reason that will still
+        be true after the mechanism does change.
+      </p>
+      <p>
+        Two fields carry the behavior. `inputs` lists every declared
+        input with a name, a JSON-compatible type, whether it's
+        required, and a constraint written as a business rule rather
+        than a validation note. `outputs` lists every declared output
+        with a name, a type, and a guarantee describing what the
+        capability promises about that value. Both fields exist so an
+        agent (or a person) can call the capability correctly without
+        reading the implementation to find out what's actually enforced.
+      </p>
+      <p>
+        It helps to notice what's absent from this floor as much as
+        what's present. There's no field for performance targets, no
+        field for error handling per condition, no field for which
+        trust zone a capability operates in. Those all exist in the
+        extended schema, but they're not required to call a contract
+        viable. The minimum viable contract is scoped deliberately
+        narrow: enough for a reader to understand what the capability
+        does, why, and where its edges are, without demanding the kind
+        of operational detail that only some capabilities actually need.
+      </p>
+      <p>
+        Two fields carry the boundary. `non_goals` states, in plain
+        declarative sentences, what the capability explicitly does not
+        do. Leaving it empty because the scope "feels obvious" is one of
+        the most common ways contracts drift, because an unstated
+        boundary is an invitation for the next change to quietly cross
+        it. `use_cases` does the opposite work: it shows the practitioner
+        scenarios the capability actually serves, written in the "as a
+        [role], I need to [action] so that [outcome]" form, grounding the
+        contract in why anyone would call this capability in the first
+        place.
+      </p>
+      <p>
+        The last field is `open_questions`, and it's arguably the most
+        honest one in the schema. It's the place to put unresolved
+        decisions instead of inventing an answer that sounds finished.
+        A contract with a filled-in `open_questions` list isn't a
+        failure. It's a contract telling the truth about what's still
+        undecided, which is worth more than a contract that pretends
+        certainty it doesn't have. The field only becomes a problem if it
+        never gets closed, since a non-empty list is what keeps `state`
+        from moving to active.
+      </p>
+      <p>
+        There's a matching rule for what not to write, and it's just as
+        important as the rule for what to include. Don't restate code
+        structure, method names, infrastructure details, or internal
+        optimization choices in a contract field, that's the code's job,
+        not the contract's. And if a field is empty because the team
+        genuinely doesn't know the answer yet, the right move is to
+        leave it open in `open_questions` rather than invent something
+        that sounds finished. A contract that guesses confidently is
+        more dangerous than one that admits what it doesn't know, because
+        the guess is the one an agent will trust.
+      </p>
+      <p>
+        In practice, you rarely fill these in from a blank file. `cdad
+        init &lt;capability-id&gt;` scaffolds the whole triple, contract.yaml,
+        contract.json, and contract.md, validates that the id follows
+        the domain/subdomain/action convention, and can pull notes
+        straight from a prior `cdad roadmap` run so the first draft
+        isn't starting from nothing. `--extended` adds the fields for
+        dependencies, performance, and error handling once a team's
+        ready for more than the minimum. `--no-prompts` writes
+        placeholders instead of asking questions interactively, useful
+        for scripting the scaffold step, but the placeholders still have
+        to get replaced with real answers before `cdad validate` will
+        call the contract clean.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/core-model/capability-graph/")}>&larr; Capability Graph</a>
+        <a href={withBase("/core-model/contract-anti-patterns/")}>Contract Anti-Patterns &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/examples.astro
+++ b/book-website/src/pages/examples.astro
@@ -1,0 +1,115 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="Examples"
+  description="A contract, a graph, an audit, and a report, walked through concretely instead of described in the abstract. This is what the methodology looks like once it's applied to something specific."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Examples</p>
+      <h1>Examples</h1>
+
+      <p>
+        Concepts like "contract" and "capability graph" are easy to nod
+        along to and hard to picture. This section exists to fix that.
+        Each page below takes one piece of the methodology and shows it
+        applied to something concrete, a real running example, a real
+        graph shape, a real report structure, instead of leaving it at the
+        level of definition.
+      </p>
+      <p>
+        Read these in order if you want the full arc: what a contract
+        actually contains, how to read the graph those contracts build,
+        what changes about a capability once it has one, and what a
+        <code>cdad check</code> report looks like when you run it for
+        real.
+      </p>
+
+      <ul class="cluster-list">
+        <li>
+          <a href={withBase("/examples/payment-retry-policy-contract/")}>Payment Retry Policy Contract</a>
+          <p>What a real contract for a real capability actually contains, walked through field by field.</p>
+        </li>
+        <li>
+          <a href={withBase("/examples/reading-a-capability-graph/")}>Reading a Capability Graph</a>
+          <p>Nodes are capabilities, edges are dependencies. How to read what the shape of a graph is telling you.</p>
+        </li>
+        <li>
+          <a href={withBase("/examples/before-and-after-a-legibility-audit/")}>Before and After a Legibility Audit</a>
+          <p>What changes about a capability once it stops relying on guesswork and starts declaring itself.</p>
+        </li>
+        <li>
+          <a href={withBase("/examples/cdad-check-output-walkthrough/")}>cdad check Output Walkthrough</a>
+          <p>What the report actually looks like: the score, the band, the findings, and the next step.</p>
+        </li>
+      </ul>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/proof/")}>&larr; Proof</a>
+        <a href={withBase("/toolkit/")}>Toolkit &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .cluster-list {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 1.25rem;
+    margin: 2rem 0;
+  }
+
+  .cluster-list a {
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: var(--border);
+    text-underline-offset: 0.15em;
+  }
+
+  .cluster-list a:hover {
+    color: var(--coral);
+    text-decoration-color: currentColor;
+  }
+
+  .cluster-list p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/examples/before-and-after-a-legibility-audit.astro
+++ b/book-website/src/pages/examples/before-and-after-a-legibility-audit.astro
@@ -1,0 +1,87 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Before and After a Legibility Audit"
+  description="What changes about a capability once it stops running on tribal knowledge and starts declaring its own behavior, boundaries, and safe extension points."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Examples</p>
+      <h1>Before and After a Legibility Audit</h1>
+
+      <p>
+        Before a capability has been through the audit, changing it is
+        mostly guesswork dressed up as confidence. An engineer opens the
+        code, reads the function that seems relevant, and forms a theory
+        about why it works the way it does. Sometimes that theory is
+        right. Often it's right about the mechanism and wrong about the
+        reason, because the reason lived in a Slack thread, a postmortem,
+        or a conversation that happened before anyone currently on the
+        team joined. An agent asked to make the same change has even less
+        to go on. It can read the code, but it can't read the room the
+        code was written in.
+      </p>
+      <p>
+        That gap is where the risky changes come from. Not from careless
+        engineers, but from a system that never wrote down its own
+        boundaries. A change that looks safe by every signal the code
+        offers can still break an exception path that only existed because
+        of a customer complaint two years ago, and nothing in the
+        repository says so.
+      </p>
+      <p>
+        After the audit, and after the resulting contract exists, the same
+        capability looks different from the outside even if not one line
+        of its implementation has changed. The behavior is declared, not
+        inferred. The boundaries are explicit: what the capability owns,
+        what it depends on, and what it deliberately refuses to do. The
+        history that used to live in someone's memory is captured as the
+        constraint it created, not just as an anecdote about an incident.
+      </p>
+      <p>
+        The practical difference shows up at the moment of change. Before,
+        extending the capability means reading everything nearby and
+        hoping you've found all the exception paths. After, extending it
+        means checking the contract first, seeing what's already promised,
+        and knowing exactly which parts are safe to touch and which
+        parts are load-bearing for a reason the contract already states.
+        That's the shift the whole methodology is built around: not making
+        the code smarter, but making what the code already knows visible
+        to whoever has to work with it next.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/examples/reading-a-capability-graph/")}>&larr; Reading a Capability Graph</a>
+        <a href={withBase("/examples/cdad-check-output-walkthrough/")}>cdad check Output Walkthrough &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/examples/cdad-check-output-walkthrough.astro
+++ b/book-website/src/pages/examples/cdad-check-output-walkthrough.astro
@@ -1,0 +1,99 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="cdad check Output Walkthrough"
+  description="A walkthrough of what cdad-report.md actually looks like: the score, the band, the per-capability findings, and the next step, illustrated rather than pulled from a real repo."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Examples</p>
+      <h1>cdad check Output Walkthrough</h1>
+
+      <p>
+        Running <code>cdad check</code> produces one file,
+        <code>cdad-report.md</code>, and that file follows the same output
+        shape every command in the CLI uses: a header, a divider, the
+        content block, any generated file paths, and a closing
+        <code>Next step</code> line. The illustration below shows the
+        structure a report takes. Treat the specific numbers as
+        illustrative, not as a real score pulled from a real customer's
+        repository.
+      </p>
+      <p>
+        Near the top sits the overall score, a single number from zero to
+        ten, next to a band that names roughly where the repo sits, from
+        something like "early" or "developing" up toward "agent-ready."
+        The score is a summary, not the useful part on its own. It exists
+        so a team can compare one run against a later one and see whether
+        the direction is right.
+      </p>
+      <p>
+        Below the headline score sits the part that actually matters day
+        to day: per-capability findings from the questionnaire. For each
+        of the capabilities walked through during the run, the report
+        notes how it scored across the four legibility questions, where
+        the answer was clearly there, where it was partial, and where
+        there was nothing to point to but tribal memory. This is the
+        section a team actually reads together, because it names specific
+        gaps instead of leaving everyone to infer them from one number.
+      </p>
+      <p>
+        The report closes with a <code>Next step</code> line, and that line
+        is what turns the check into a workflow instead of a one-off
+        diagnostic. It's the reminder that the report itself isn't the
+        destination. It's the input <code>cdad roadmap</code> reads next,
+        the file that turns "here's where the gaps are" into "here's what
+        to contract first."
+      </p>
+      <p>
+        Run the check again after a few extraction passes and you get a
+        second report to set beside the first one. The value isn't in
+        any single run's number. It's in watching the band move, and the
+        per-capability findings shrink, as more of the system starts
+        declaring itself instead of relying on whoever happens to remember
+        why it works.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/examples/before-and-after-a-legibility-audit/")}>&larr; Before and After a Legibility Audit</a>
+        <a href={withBase("/examples/")}>Examples overview &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/examples/payment-retry-policy-contract.astro
+++ b/book-website/src/pages/examples/payment-retry-policy-contract.astro
@@ -1,0 +1,95 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Payment Retry Policy Contract"
+  description="The payment retry policy from Meridian's payments domain is the example that runs through the whole book. Here's what a real contract for it would actually need to say."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Examples</p>
+      <h1>Payment Retry Policy Contract</h1>
+
+      <p>
+        The running example throughout the book, and in the appendix's
+        schema reference, is the payment retry policy from Meridian's
+        payments domain. It's a good example precisely because it's not
+        exotic. Every team with a payments surface has some version of it:
+        code that decides whether to try charging a customer again after a
+        failure, and how many times, and under what conditions it should
+        stop trying.
+      </p>
+      <p>
+        A contract for that capability doesn't start with implementation
+        detail. It starts with what the capability does, described in
+        plain language a new engineer or an agent can act on without
+        reading the retry loop line by line: it decides whether and when
+        to retry a failed payment attempt, and what happens once retries
+        are exhausted.
+      </p>
+      <p>
+        Then it says why. This is the part most codebases never write
+        down. Retries aren't attempted on every failure the same way,
+        because some failures mean the card was declined and trying again
+        immediately just annoys the customer, while others mean the
+        gateway timed out and the original charge may or may not have gone
+        through. The contract states that distinction instead of leaving
+        it as something only the engineer who wrote the original ticket
+        remembers.
+      </p>
+      <p>
+        It also declares what the capability needs: which upstream signal
+        tells it a charge is safe to retry, what idempotency guarantee it
+        depends on so a retry can't double-charge someone, and what
+        configuration or account state it reads before deciding to try
+        again. It declares what it promises: a bounded number of attempts,
+        a predictable backoff shape, a final state the rest of the system
+        can rely on once retries stop. And it declares what it explicitly
+        doesn't do, which matters just as much. It doesn't decide refund
+        policy, it doesn't touch dispute handling, and it doesn't retry
+        past the point where the payment provider has told it to stop.
+        Leaving that boundary unstated is exactly how a capability quietly
+        grows scope nobody signed up for.
+      </p>
+      <p>
+        None of that requires reproducing a full schema here. The point of
+        walking through it in prose is to show that a contract isn't
+        paperwork bolted onto working code. It's the part of the
+        capability that was always true, made readable to whoever, or
+        whatever, has to change it next.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/examples/")}>&larr; Examples</a>
+        <a href={withBase("/examples/reading-a-capability-graph/")}>Reading a Capability Graph &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/examples/reading-a-capability-graph.astro
+++ b/book-website/src/pages/examples/reading-a-capability-graph.astro
@@ -1,0 +1,104 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Reading a Capability Graph"
+  description="Nodes are capabilities, edges are dependencies. A short walkthrough of how to read what cdad graph actually shows you, and what a well-connected or isolated node means."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Examples</p>
+      <h1>Reading a Capability Graph</h1>
+
+      <p>
+        A capability graph looks like a lot of other diagrams you've
+        probably seen: boxes connected by arrows. What makes it different
+        is what the boxes and arrows are actually made of. Each node is a
+        capability with a real contract behind it, not a service boundary
+        drawn from memory or a box added to make an architecture diagram
+        look complete. Each edge is a dependency that the contracts
+        themselves declare, one capability stating that it needs another
+        to do its job.
+      </p>
+      <p>
+        Reading the graph is mostly about noticing shape. A capability
+        with several edges pointing into it is one that a lot of the
+        system leans on, which usually means it deserves a higher bar for
+        legibility, since a change there can propagate further than a
+        change to something more isolated. A node sitting off by itself
+        with no edges either way is worth a second look too, for the
+        opposite reason. Sometimes that isolation is correct, a genuinely
+        self-contained capability. Sometimes it just means nobody has
+        contracted its neighbors yet, so the dependency exists in the code
+        but hasn't shown up in the graph.
+      </p>
+      <p>
+        <code>cdad graph</code> renders this in three formats at once. The
+        Mermaid output is what you'd actually look at, a diagram you can
+        drop into a doc or a PR description. The Markdown output gives you
+        the same information in a form that reads well inline. The JSON
+        adjacency list is the one worth treating as the source of truth if
+        you're feeding graph state into other tooling, an agent, a CI
+        check, a dashboard, because it's the stable, machine-friendly
+        format the other two are rendered from.
+      </p>
+      <p>
+        You can also scope a run instead of rendering the whole thing at
+        once. <code>--capability &lt;id&gt;</code> narrows the graph to one
+        capability and its immediate neighbors, useful when you're about to
+        touch something and want to know what else might feel it.
+        <code>--domain &lt;name&gt;</code> narrows to a domain, and
+        <code>--state &lt;state&gt;</code> filters by lifecycle state, which
+        matters once a repo has a mix of contracted and not-yet-contracted
+        capabilities living side by side.
+      </p>
+      <p>
+        The graph is only as trustworthy as the contracts behind it,
+        though. It reflects what the contracts declare, not what prose
+        documentation says elsewhere, so if a dependency relationship
+        changes, the fix goes into the contract first and the graph gets
+        regenerated after, not the other way around.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/examples/payment-retry-policy-contract/")}>&larr; Payment Retry Policy Contract</a>
+        <a href={withBase("/examples/before-and-after-a-legibility-audit/")}>Before and After a Legibility Audit &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/excerpt.astro
+++ b/book-website/src/pages/excerpt.astro
@@ -5,7 +5,7 @@ import BuyLinks from "../components/BuyLinks.astro";
 
 <BaseLayout
   title="Excerpt"
-  description="Read the opening scene from The Day After: an AI agent ships a clean, fast, correct-looking change — and production breaks anyway. Free excerpt."
+  description="Read the opening scene from The Day After: an AI agent ships a clean, fast, correct-looking change, and production breaks anyway. Free excerpt."
 >
   <section class="section">
     <div class="wrap">
@@ -55,7 +55,7 @@ import BuyLinks from "../components/BuyLinks.astro";
 
       <p class="excerpt__cta">
         The agent did everything right. So did the developer. What broke
-        wasn't the code &mdash; it's the reason the book exists. Keep
+        wasn't the code. It's the reason the book exists. Keep
         reading in <em>The Day After</em>.
       </p>
       <BuyLinks />

--- a/book-website/src/pages/extraction-over-refactoring.astro
+++ b/book-website/src/pages/extraction-over-refactoring.astro
@@ -6,7 +6,7 @@ import { withBase } from "../utils/url";
 
 <BaseLayout
   title="Extraction Over Refactoring"
-  description="Why the instinctive fix for a legacy system — a full refactor — is the expensive trap, and what to do instead: extract one capability at a time."
+  description="Why the instinctive fix for a legacy system, a full refactor, is the expensive trap, and what to do instead: extract one capability at a time."
 >
   <section class="section">
     <div class="wrap">
@@ -17,7 +17,7 @@ import { withBase } from "../utils/url";
         Code is cheap. Alignment is not. Chapter 5 opens on the response
         most organizations reach for once they recognize the legibility
         problem: schedule a refactor. Clean up the accumulation, and the
-        navigation problem resolves &mdash; or so the reasoning goes.
+        navigation problem resolves, or so the reasoning goes.
       </p>
       <p>
         The chapter makes the case that this is a trap, not a fix. A
@@ -26,7 +26,7 @@ import { withBase } from "../utils/url";
         new developer can read without flinching. What it does not produce
         is a system that declares what it knows. Point an agent at the
         refactored system, and it fails for the exact same reasons it
-        failed before the first planning meeting &mdash; because legibility
+        failed before the first planning meeting, because legibility
         is a property of declared contracts, not clean code.
       </p>
       <p>
@@ -40,7 +40,7 @@ import { withBase } from "../utils/url";
       <BuyLinks />
 
       <nav class="chapter-nav" aria-label="Chapter navigation">
-        <a href={withBase("/capabilities-graph/")}>&larr; Chapter 4 &mdash; The Capabilities Graph</a>
+        <a href={withBase("/capabilities-graph/")}>&larr; Chapter 4: The Capabilities Graph</a>
         <a href={withBase("/about-the-book/")}>Full table of contents &rarr;</a>
       </nav>
     </div>

--- a/book-website/src/pages/faq.astro
+++ b/book-website/src/pages/faq.astro
@@ -1,0 +1,188 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="FAQ"
+  description="Answers to the questions that come up most about the book, The Day After, and its companion open source toolkit, cdad."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">FAQ</p>
+      <h1>Frequently Asked Questions</h1>
+
+      <p>
+        <a href={withBase("/")}>&larr; Back to home</a>
+      </p>
+
+      <p>
+        Straight answers to the questions that come up most, about the
+        book and about the toolkit it ships alongside.
+      </p>
+
+      <div class="faq-item">
+        <h2>What is The Day After actually about?</h2>
+        <p>
+          It's about why AI coding agents keep making unsafe changes to
+          real codebases, and it argues the cause isn't the agents. It's
+          that most software never wrote down why it works the way it
+          does. The book calls that missing layer tribal knowledge, and
+          walks through a methodology, contracts, capabilities, and a
+          capability graph, for making it explicit instead of leaving it
+          in people's heads.
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h2>Who is the book for?</h2>
+        <p>
+          Engineers, architects, and engineering leaders working in
+          codebases that are starting to have AI agents open pull requests
+          against them. It's also written with product managers and
+          designers in mind, since a few chapters address what this shift
+          means for their side of the work, not just the code itself.
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h2>Is it a technical book or a business book?</h2>
+        <p>
+          Both, on purpose. The core argument is technical, contracts,
+          graphs, extraction priority, but it's written so a
+          non-engineering reader in the same organization can follow the
+          reasoning and understand what's being asked of their team.
+          Nobody needs a computer science degree to get through it, and
+          nobody working in code will find it thin.
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h2>Where can I buy the book?</h2>
+        <p>
+          Links to the current retailers are on the homepage and repeated
+          at the bottom of every page on this site, right below the main
+          content.
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h2>Do I need to be an AI or machine learning expert to read it?</h2>
+        <p>
+          No. The book isn't about how models work internally. It's about
+          how to make a codebase safe for an agent, or a new hire, to
+          operate in without tribal knowledge. If you've worked on a
+          production codebase, you already have the background it assumes.
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h2>Is the cdad CLI free?</h2>
+        <p>
+          Yes. It's an open source command-line tool you install and run
+          against your own repository. There's no paid tier gating the
+          commands described on this site.
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h2>Is the toolkit actually open source?</h2>
+        <p>
+          Yes, the CLI, the contract schemas, and the validation logic are
+          all public in the companion GitHub repository. You can read
+          exactly how a report gets scored or a contract gets validated
+          instead of taking a description of it on faith.
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h2>What languages or stacks does the toolkit work with?</h2>
+        <p>
+          Conceptually, any codebase organized around business capabilities
+          rather than a specific framework. The methodology, and the
+          contract format it produces, isn't tied to one language. The
+          questionnaire in <code>cdad check</code> asks about behavior and
+          exception paths, not syntax, so it applies whether the
+          capability underneath is written in one language or several.
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h2>Do I need to read the book to use the toolkit?</h2>
+        <p>
+          No. You can install <code>cdad</code>, run <code>cdad check</code>
+          against a repository, and follow the reports it produces without
+          having read a page of the book first. The book is what explains
+          the reasoning behind why the tool asks the questions it asks, and
+          most people find that context makes the later steps, especially
+          prioritizing extraction, easier to trust.
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h2>How is a contract different from documentation?</h2>
+        <p>
+          Documentation describes a system and drifts out of date the
+          moment the code changes underneath it. A contract is validated,
+          versioned, and machine-readable, so <code>cdad validate</code>
+          can catch it when the contract and the code it describes fall out
+          of sync. Documentation is a description. A contract is closer to
+          a checked promise.
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h2>What does legibility mean in this context?</h2>
+        <p>
+          It's the degree to which a capable engineer, or an agent, can
+          understand why a capability behaves the way it does without
+          relying on tribal knowledge nobody wrote down. It's measured
+          with a short questionnaire covering four questions, and the
+          resulting score is what the toolkit uses to find where the risk
+          actually sits.
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h2>Does adopting this mean rewriting our codebase?</h2>
+        <p>
+          No, and that's a deliberate part of the argument. The
+          methodology is built around extraction, contracting one
+          capability at a time inside the codebase you already have,
+          rather than a rewrite that consumes months of senior engineering
+          time and still doesn't declare what the new code knows.
+        </p>
+      </div>
+
+      <BuyLinks />
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .faq-item {
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+  }
+
+  .faq-item h2 {
+    font-size: 1.15rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+  }
+
+  .faq-item p {
+    margin: 0;
+    color: var(--text-muted);
+  }
+</style>

--- a/book-website/src/pages/for-architects.astro
+++ b/book-website/src/pages/for-architects.astro
@@ -1,0 +1,76 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="The Architect"
+  description="The architect's role didn't get more important when AI agents showed up. It was always this important. Chapter 7 is about what finally lets the system carry an architect's judgment at scale."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Chapter 7 &middot; Part III: The Transformation</p>
+      <h1>The Architect</h1>
+
+      <p>
+        For years, the real limit on an architect's influence wasn't the
+        quality of their thinking. It was the size of their calendar. One
+        person holding a system's coherence across dozens of teams can only
+        be in so many rooms. Whatever judgment lived in their head reached
+        the rest of the org through meetings, reviews, and documents that
+        described intent without ever enforcing it. Chapter 7 argues that
+        contracts change the mechanics of that entirely: a constraint
+        written into a contract travels with its capability into every
+        pipeline check, every agent session, every pull request that
+        touches it, without needing the architect in the room.
+      </p>
+      <p>
+        The chapter opens with something a lot of architects have felt
+        before they had a name for it. The RFC an agent produced in forty
+        minutes that would've taken two days. The proof of concept that
+        showed up fully built in standup, against a codebase it took six
+        months to make coherent. The review where the change was already
+        scoped and its impact already traced three layers deep, work
+        that used to be the architect's alone. Each moment on its own is
+        impressive. Stacked up, they raise a question most architects
+        haven't said out loud: if execution is what agents do now, what's
+        actually left for me?
+      </p>
+      <p>
+        Chapter 7 answers that directly, not with reassurance but with a
+        real account of what expands in an architect's daily practice, and
+        what the shift demands from everyone they work with.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Chapter navigation">
+        <a href={withBase("/contract-lifecycle/")}>&larr; Chapter 6: The Contract Lifecycle</a>
+        <a href={withBase("/for-developers/")}>Chapter 8: The Developer &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/for-designers.astro
+++ b/book-website/src/pages/for-designers.astro
@@ -1,0 +1,74 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="The Designer"
+  description="A designer can explain forty minutes of decisions a Figma file will never show. Chapter 10 is about what happens when that reasoning has to become something an agent can read."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Chapter 10 &middot; Part III: The Transformation</p>
+      <h1>The Designer</h1>
+
+      <p>
+        The design review just ended. Laptops are closing. Over the last
+        forty minutes, the designer explained things that live in no file
+        the company keeps. Why a component is named for what it does
+        instead of where it sits on the screen. Why a destructive action
+        renders differently on mobile, not as a style choice but because
+        the confirmation behavior has to change and that rule has never
+        been written down anywhere but her head. Why a verification flow
+        has three steps instead of one, a decision made two years ago with
+        legal, for a reason she's now the only person left who remembers.
+      </p>
+      <p>
+        Everyone in that room understood what to build. Chapter 10 points
+        out that none of the reasoning that produced that understanding
+        exists in an artifact anyone else can open. The Figma file shows
+        what things look like. The design system documents tokens and
+        components. Neither one was built to carry a behavioral rule
+        forward, let alone hand it to an agent generating a new surface
+        six months later.
+      </p>
+      <p>
+        This is the chapter about what it means to design an interaction
+        contract instead of just a screen. Not a new set of Figma layers,
+        but a way of writing down the behavioral logic a designer already
+        holds, so the decision doesn't quietly disappear the day she's not
+        in the room to explain it again.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Chapter navigation">
+        <a href={withBase("/for-product-managers/")}>&larr; Chapter 9: The PM / PO</a>
+        <a href={withBase("/for-engineering-leaders/")}>Chapter 11: The Leadership Team &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/for-developers.astro
+++ b/book-website/src/pages/for-developers.astro
@@ -1,0 +1,78 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="The Developer"
+  description="Agents write production code today, in real repositories, against real requirements. Chapter 8 asks the question most developers haven't said out loud yet, and answers it honestly."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Chapter 8 &middot; Part III: The Transformation</p>
+      <h1>The Developer</h1>
+
+      <p>
+        Agents write production code today. Not in a sandbox, not in a
+        demo. In real repositories, against real requirements, producing
+        code that gets reviewed, approved, and merged into systems people
+        depend on. If your team hasn't seen that yet, you will soon. If
+        you have, you've probably felt the question that follows, the one
+        most developers haven't said out loud because saying it makes it
+        more real than it's comfortable to be.
+      </p>
+      <p>
+        The question isn't whether agents can write code. That's settled.
+        It's what this means for you, specifically, in the role you built
+        with the skills you spent years developing. Chapter 8 is blunt
+        about the answer depending almost entirely on which developer you
+        are. A developer whose value has mostly been the volume and
+        velocity of code produced, tickets closed, features shipped, is in
+        a genuinely hard spot, and pretending otherwise isn't kindness.
+        That's exactly the work agents are getting better at.
+      </p>
+      <p>
+        A different developer, one whose value was always harder to
+        measure because it lived in judgment rather than output, is in the
+        opposite position. The one who knew why a constraint existed, not
+        just what it did. Who could look at an agent's output and know,
+        before running a test, that it would fail on the edge case nobody
+        documented. That developer isn't being replaced. They're in more
+        demand than ever, because code is flowing at a volume no
+        engineering org has had to govern before, and someone has to be
+        accountable for what it does. Chapter 8 is about becoming that
+        developer on purpose.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Chapter navigation">
+        <a href={withBase("/for-architects/")}>&larr; Chapter 7: The Architect</a>
+        <a href={withBase("/for-product-managers/")}>Chapter 9: The PM / PO &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/for-engineering-leaders.astro
+++ b/book-website/src/pages/for-engineering-leaders.astro
@@ -1,0 +1,76 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="The Leadership Team"
+  description="Every other chapter in the book is about the work. Chapter 11 is about the decision that has to happen before any of that work is possible: how much autonomy to hand to agents, and how to restructure for it."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Chapter 11 &middot; Part III: The Transformation</p>
+      <h1>The Leadership Team</h1>
+
+      <p>
+        Every other role in this book gets a chapter about how their daily
+        work changes once contracts exist. Leadership's chapter is
+        different, because leadership's job is deciding whether the rest
+        of this happens at all. How much autonomy an agent actually earns
+        on a given system. Whether extraction gets funded as a real
+        program or squeezed into whatever time is left after the roadmap.
+        Whether the engineers whose tribal knowledge is quietly holding
+        the company together see the shift as a threat to their value or
+        a way to make it permanent.
+      </p>
+      <p>
+        Chapter 11 doesn't treat that as a soft, cultural problem separate
+        from the technical one. The two are the same problem. A capability
+        graph that nobody funded the time to build doesn't exist no matter
+        how sound the argument for it is. A senior engineer who reads the
+        extraction program as "tell us everything you know so we need you
+        less" will, understandably, slow-walk it. The chapter is about
+        making the restructuring case in terms a leadership team actually
+        has to weigh: what it costs to do this, what it costs not to, and
+        why the second number grows every quarter the decision gets
+        deferred.
+      </p>
+      <p>
+        It ends where a leadership chapter has to end: with what to
+        actually do Monday morning, at whatever scale you're operating at,
+        whether that's a two-hundred-person engineering org or a team of
+        twelve trying to get ahead of a problem before it's load-bearing.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Chapter navigation">
+        <a href={withBase("/for-designers/")}>&larr; Chapter 10: The Designer</a>
+        <a href={withBase("/company-that-gets-there-first/")}>Chapter 12: The Company That Gets There First &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/for-product-managers.astro
+++ b/book-website/src/pages/for-product-managers.astro
@@ -1,0 +1,76 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="The PM / PO"
+  description="A PM leaves the room knowing why a decision was made, not just what to build. Chapter 9 is about the gap between that knowledge and the ticket, and what closes it."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Chapter 9 &middot; Part III: The Transformation</p>
+      <h1>The PM / PO</h1>
+
+      <p>
+        Every important decision about a capability gets made in a room. A
+        business rule gets set, a constraint gets named, a whole feature
+        category gets ruled out for reasons the PM understands better than
+        anyone else there, because they're the one who's been talking to
+        the customer for six months. They leave that room holding
+        something nobody else has in the same complete form: not just what
+        gets built, but why it exists and what the team deliberately chose
+        not to do.
+      </p>
+      <p>
+        Then they open Jira and write a ticket. The ticket says what will
+        be built. It doesn't say what was decided. It can't carry the
+        regulatory constraint that shaped the limit, or the customer whose
+        contract drew the boundary, or the direction the team considered
+        and rejected. Chapter 9 makes the case that this was never a
+        failure of documentation. The ticket, the PRD, the wiki page, none
+        of them were built to hold what a PM actually knows. For years the
+        gap got absorbed quietly, by developers who'd sat in enough
+        meetings to fill in the blanks, by architects who caught the edge
+        cases in review.
+      </p>
+      <p>
+        Agents don't sit in those meetings. They read the ticket, and only
+        the ticket. Chapter 9 is about what changes when the spec itself
+        becomes the artifact that carries intent, and what it looks like
+        for a PM to write one that an agent can actually be trusted to
+        build from.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Chapter navigation">
+        <a href={withBase("/for-developers/")}>&larr; Chapter 8: The Developer</a>
+        <a href={withBase("/for-designers/")}>Chapter 10: The Designer &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/glossary.astro
+++ b/book-website/src/pages/glossary.astro
@@ -1,0 +1,119 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="Glossary"
+  description="Short, plain definitions for the vocabulary of Contract-Driven AI Development: legibility, capability, contract, the capability graph, and the terms around them."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Quick Reference</p>
+      <h1>Glossary</h1>
+
+      <p>
+        The book and the toolkit share a small vocabulary, and it shows
+        up everywhere once you know it. These are the short, dictionary
+        versions of the ten terms that matter most, each one linking
+        back to where the idea gets its full treatment.
+      </p>
+
+      <ul class="cluster-list">
+        <li>
+          <a href={withBase("/glossary/agent-readiness/")}>Agent Readiness</a>
+          <p>The 0 to 10 score, with a band, that <code>cdad check</code> produces for a repo.</p>
+        </li>
+        <li>
+          <a href={withBase("/glossary/capability/")}>Capability</a>
+          <p>A business-facing unit of behavior with inputs, outputs, and non-goals.</p>
+        </li>
+        <li>
+          <a href={withBase("/glossary/capability-graph/")}>Capability Graph</a>
+          <p>The directed dependency map of every contract in a repo.</p>
+        </li>
+        <li>
+          <a href={withBase("/glossary/contract/")}>Contract</a>
+          <p>The declaration of what a capability does, needs, promises, and won't do.</p>
+        </li>
+        <li>
+          <a href={withBase("/glossary/contract-driven-ai-development/")}>Contract-Driven AI Development</a>
+          <p>C-DAD, the discipline the book and toolkit are both built around.</p>
+        </li>
+        <li>
+          <a href={withBase("/glossary/extraction/")}>Extraction</a>
+          <p>Pulling a capability out of tribal knowledge and into a contract.</p>
+        </li>
+        <li>
+          <a href={withBase("/glossary/legibility/")}>Legibility</a>
+          <p>Whether a capability's behavior can be understood without tribal knowledge.</p>
+        </li>
+        <li>
+          <a href={withBase("/glossary/minimum-viable-contract/")}>Minimum Viable Contract</a>
+          <p>The smallest set of fields a contract needs to be useful.</p>
+        </li>
+        <li>
+          <a href={withBase("/glossary/non-goals/")}>Non-Goals</a>
+          <p>The explicit statement of what a capability deliberately does not do.</p>
+        </li>
+        <li>
+          <a href={withBase("/glossary/tribal-knowledge/")}>Tribal Knowledge</a>
+          <p>Undocumented operational knowledge that lives in people's heads, not in the system.</p>
+        </li>
+      </ul>
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/how-c-dad-works/")}>&larr; How C-DAD Works</a>
+        <a href={withBase("/comparisons/")}>Comparisons &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .cluster-list {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 1.25rem;
+    margin: 2rem 0;
+  }
+
+  .cluster-list a {
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: var(--border);
+    text-underline-offset: 0.15em;
+  }
+
+  .cluster-list a:hover {
+    color: var(--coral);
+    text-decoration-color: currentColor;
+  }
+
+  .cluster-list p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/glossary/agent-readiness.astro
+++ b/book-website/src/pages/glossary/agent-readiness.astro
@@ -1,0 +1,63 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Agent Readiness: Glossary"
+  description="Agent readiness is a 0 to 10 score with a named band, produced by cdad check, that measures how safely an AI agent could work on a repo's capabilities without tribal knowledge."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Glossary</p>
+      <h1>Agent Readiness</h1>
+
+      <p>
+        Hand your repo to an AI agent tomorrow. How much would it get
+        wrong? Agent readiness is the toolkit's attempt to answer that
+        with a number instead of a guess, a 0 to 10 score with a band,
+        produced by <code>cdad check</code>.
+      </p>
+      <p>
+        The score combines two signals: a static scan of the repo, and a
+        legibility questionnaire that asks up to five capabilities the
+        same four questions an audit would ask. Together they produce
+        <code>cdad-report.md</code>, the baseline everything else in the
+        workflow builds on.
+      </p>
+      <p>
+        A low score isn't a verdict on the team, it's a map. Feed that
+        report into <code>cdad roadmap</code> and the lowest-scoring,
+        highest-risk capabilities rise to the top of what gets
+        <a href={withBase("/glossary/extraction/")}>extracted</a> first.
+      </p>
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/glossary/")}>&larr; Glossary</a>
+        <a href={withBase("/core-model/")}>Learn more in the Core Model &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/glossary/capability-graph.astro
+++ b/book-website/src/pages/glossary/capability-graph.astro
@@ -1,0 +1,62 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Capability Graph: Glossary"
+  description="The capability graph is the directed dependency map of every contract in a repo, showing how capabilities connect and where extraction work still remains."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Glossary</p>
+      <h1>Capability Graph</h1>
+
+      <p>
+        Once a handful of capabilities have contracts, a natural question
+        shows up: how do they depend on each other? The capability graph
+        answers it. <code>cdad graph</code> walks every contract in the
+        repo and renders the result as Mermaid, JSON, and Markdown, a
+        directed map of what calls what.
+      </p>
+      <p>
+        The JSON adjacency list is the one worth building tooling
+        against. It's intentionally stable and meant for agents to
+        consume directly, not just for humans skimming a diagram during
+        review.
+      </p>
+      <p>
+        A capability graph with large unlabeled gaps is really a map of
+        where <a href={withBase("/glossary/extraction/")}>extraction</a>
+        still needs to happen.
+      </p>
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/glossary/")}>&larr; Glossary</a>
+        <a href={withBase("/core-model/")}>Learn more in the Core Model &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/glossary/capability.astro
+++ b/book-website/src/pages/glossary/capability.astro
@@ -1,0 +1,64 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Capability: Glossary"
+  description="A capability is a business-facing unit of behavior, with inputs, outputs, and explicit non-goals, that a contract can describe and a graph can connect."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Glossary</p>
+      <h1>Capability</h1>
+
+      <p>
+        Not every function or class deserves its own contract. A
+        capability is the business-facing slice that does, the retry
+        policy, the discount calculation, the onboarding flow. It has a
+        name a product person would recognize, plus inputs, outputs, and
+        a stated boundary of what it deliberately leaves out.
+      </p>
+      <p>
+        Capabilities are the unit the whole toolkit is built around.
+        Contracts describe capabilities. The capability graph maps how
+        they depend on each other. <code>cdad init</code> scaffolds one
+        capability at a time, in <code>domain/subdomain/action</code>
+        form, so the granularity stays consistent as a repo grows.
+      </p>
+      <p>
+        Get the boundary wrong, usually by leaving the
+        <a href={withBase("/glossary/non-goals/")}>non-goals</a> empty,
+        and the capability's <a href={withBase("/glossary/contract/")}>contract</a>
+        stops meaning anything precise.
+      </p>
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/glossary/")}>&larr; Glossary</a>
+        <a href={withBase("/core-model/")}>Learn more in the Core Model &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/glossary/contract-driven-ai-development.astro
+++ b/book-website/src/pages/glossary/contract-driven-ai-development.astro
@@ -1,0 +1,63 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Contract-Driven AI Development: Glossary"
+  description="Contract-Driven AI Development, or C-DAD, is the discipline of declaring what a system knows about itself through contracts, so humans and AI agents can both act on it safely."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Glossary</p>
+      <h1>Contract-Driven AI Development</h1>
+
+      <p>
+        C-DAD is the discipline the book and the toolkit are both named
+        after. Short for Contract-Driven AI Development, it's the
+        practice of making a system explain itself through contracts,
+        instead of through whoever happens to remember.
+      </p>
+      <p>
+        In practice that means treating every capability's intent,
+        dependencies, and boundaries as something written down and
+        checkable, not something inferred from old commit messages. The
+        four core ideas, legibility, capability, contract, and the
+        capability graph, are the vocabulary C-DAD is built from.
+      </p>
+      <p>
+        The <code>cdad</code> CLI is the executable half of the
+        discipline: <code>check</code>, <code>roadmap</code>,
+        <code>init</code>, <code>validate</code>, and <code>graph</code>
+        walk a repo from unmeasured to mapped, one capability at a time.
+      </p>
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/glossary/")}>&larr; Glossary</a>
+        <a href={withBase("/core-model/")}>Learn more in the Core Model &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/glossary/contract.astro
+++ b/book-website/src/pages/glossary/contract.astro
@@ -1,0 +1,65 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Contract: Glossary"
+  description="A contract is the machine-readable and human-readable declaration of what a capability does, what it needs, what it promises, and what it explicitly does not do."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Glossary</p>
+      <h1>Contract</h1>
+
+      <p>
+        Ask a contract what a capability does, and it actually answers.
+        A contract is the declaration, both machine-readable and
+        human-readable, of what a capability does, what it needs to run,
+        what it promises to callers, and what it deliberately does not
+        do.
+      </p>
+      <p>
+        <code>cdad init</code> scaffolds a contract as three files:
+        <code>contract.yaml</code> as the source of truth, plus generated
+        <code>contract.json</code> and <code>contract.md</code>. Editing
+        the generated files by hand and leaving the YAML untouched is one
+        of the toolkit's named anti-patterns, because the three copies
+        drift apart and nobody can tell which one is real.
+      </p>
+      <p>
+        Every contract in a repo becomes one node in the
+        <a href={withBase("/glossary/capability-graph/")}>capability graph</a>,
+        so a change to one contract's dependencies is visible before it
+        turns into a surprise.
+      </p>
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/glossary/")}>&larr; Glossary</a>
+        <a href={withBase("/core-model/")}>Learn more in the Core Model &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/glossary/extraction.astro
+++ b/book-website/src/pages/glossary/extraction.astro
@@ -1,0 +1,63 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Extraction: Glossary"
+  description="Extraction is the process of pulling a capability out of undocumented code and tribal knowledge and turning it into an explicit, legible contract."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Glossary</p>
+      <h1>Extraction</h1>
+
+      <p>
+        You can't contract everything on day one. Extraction is the
+        deliberate work of choosing which capability to pull out of
+        undocumented code first, writing its contract, and making its
+        behavior legible to the next reader, human or agent.
+      </p>
+      <p>
+        <code>cdad roadmap</code> is what turns extraction from a gut
+        call into a ranked list. It reads the baseline from
+        <code>cdad check</code>, asks for each capability's criticality
+        and how often it actually gets touched, and multiplies the three
+        axes together to produce an order.
+      </p>
+      <p>
+        The output is <code>cdad-roadmap.md</code>, the list you hand to
+        <code>cdad init</code> one capability at a time. See
+        <a href={withBase("/glossary/agent-readiness/")}>agent readiness</a>
+        for the score extraction is meant to move.
+      </p>
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/glossary/")}>&larr; Glossary</a>
+        <a href={withBase("/core-model/")}>Learn more in the Core Model &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/glossary/legibility.astro
+++ b/book-website/src/pages/glossary/legibility.astro
@@ -1,0 +1,65 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Legibility: Glossary"
+  description="Legibility is the degree to which an engineer or AI agent can understand why a capability behaves the way it does, without relying on tribal knowledge."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Glossary</p>
+      <h1>Legibility</h1>
+
+      <p>
+        A system is legible when a capable engineer, or an AI agent, can
+        look at a piece of behavior and understand why it works that way,
+        without hunting down the one person who remembers.
+      </p>
+      <p>
+        Most codebases run fine and stay illegible at the same time. The
+        tests pass. The service ships. Nobody can say why a particular
+        retry limit exists, or why one customer segment gets a special
+        code path. That gap between working and understood is where
+        tribal knowledge does its quiet, load-bearing work, and where an
+        agent handed the same task starts to guess.
+      </p>
+      <p>
+        The toolkit treats legibility as something you can score, not
+        something you feel. A handful of short questions, about intent,
+        history, dependency choices, and exceptions, turn that vague
+        unease into a number you can compare across capabilities. See
+        <a href={withBase("/glossary/tribal-knowledge/")}>tribal knowledge</a>
+        for the failure mode legibility is meant to fix.
+      </p>
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/glossary/")}>&larr; Glossary</a>
+        <a href={withBase("/core-model/")}>Learn more in the Core Model &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/glossary/minimum-viable-contract.astro
+++ b/book-website/src/pages/glossary/minimum-viable-contract.astro
@@ -1,0 +1,65 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Minimum Viable Contract: Glossary"
+  description="The minimum viable contract is the smallest set of fields, name, inputs, outputs, and non-goals, a contract needs to make a capability legible."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Glossary</p>
+      <h1>Minimum Viable Contract</h1>
+
+      <p>
+        Not every capability needs the full extended contract on day
+        one. The minimum viable contract is the smaller version, just
+        enough fields to make a capability legible: a name, its inputs
+        and outputs, what it promises, and what it explicitly leaves
+        out.
+      </p>
+      <p>
+        It's the default <code>cdad init</code> scaffolds unless you pass
+        <code>--extended</code>. For a lot of capabilities it's also the
+        right stopping point. More fields don't automatically mean more
+        legibility, and a contract nobody finishes filling out is worse
+        than a short one that's actually complete.
+      </p>
+      <p>
+        The appendix's
+        <a href={withBase("/appendix/contract-schema-reference/")}>Contract Schema Reference</a>
+        shows both the minimum viable and extended versions filled in
+        side by side, so the first one you write doesn't start from a
+        blank page.
+      </p>
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/glossary/")}>&larr; Glossary</a>
+        <a href={withBase("/core-model/")}>Learn more in the Core Model &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/glossary/non-goals.astro
+++ b/book-website/src/pages/glossary/non-goals.astro
@@ -1,0 +1,63 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Non-Goals: Glossary"
+  description="Non-goals are the explicit statement, inside a contract, of what a capability does not do, so its scope can't quietly expand."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Glossary</p>
+      <h1>Non-Goals</h1>
+
+      <p>
+        A contract that only says what a capability does is half
+        finished. Non-goals are the other half, an explicit list of what
+        the capability deliberately does not handle, written down so the
+        next person doesn't expand it by accident.
+      </p>
+      <p>
+        Leaving <code>non_goals</code> blank because the scope feels
+        obvious is one of the toolkit's named anti-patterns. It feels
+        harmless in the moment and turns into a real problem the first
+        time someone extends a capability into territory it was never
+        meant to cover, and review has no boundary left to point at.
+      </p>
+      <p>
+        Non-goals pair with inputs and outputs to define a capability's
+        edges. Together they're what makes a
+        <a href={withBase("/glossary/contract/")}>contract</a> something
+        you can trust instead of something you have to reverse-engineer.
+      </p>
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/glossary/")}>&larr; Glossary</a>
+        <a href={withBase("/core-model/")}>Learn more in the Core Model &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/glossary/tribal-knowledge.astro
+++ b/book-website/src/pages/glossary/tribal-knowledge.astro
@@ -1,0 +1,65 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Tribal Knowledge: Glossary"
+  description="Tribal knowledge is undocumented operational knowledge about how and why a system behaves as it does, that lives only in people's heads instead of in the system itself."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Glossary</p>
+      <h1>Tribal Knowledge</h1>
+
+      <p>
+        Every team has it. The reason the batch job runs at 2am and not
+        3am. The one customer whose contract quietly bent a validation
+        rule three years ago. None of it is written down anywhere the
+        system can produce on its own, it lives in a few people's heads,
+        and it evaporates the moment those people change teams.
+      </p>
+      <p>
+        Tribal knowledge isn't a character flaw. It's what happens by
+        default when documentation lags behind decisions. The trouble
+        starts when an engineer, or an AI agent, needs to change that
+        code and has no way to ask why it's shaped the way it is.
+      </p>
+      <p>
+        The toolkit exists to convert as much tribal knowledge as
+        possible into contracts. See
+        <a href={withBase("/glossary/legibility/")}>legibility</a> for how
+        that gets measured, and
+        <a href={withBase("/glossary/contract-driven-ai-development/")}>Contract-Driven AI Development</a>
+        for the discipline built around doing it on purpose.
+      </p>
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/glossary/")}>&larr; Glossary</a>
+        <a href={withBase("/core-model/")}>Learn more in the Core Model &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/how-c-dad-works.astro
+++ b/book-website/src/pages/how-c-dad-works.astro
@@ -1,0 +1,126 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="How C-DAD Works"
+  description="A walkthrough of the cdad CLI: check, roadmap, init, validate, and graph, the five commands that turn a diagnostic into a running contract-driven workflow."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">How C-DAD Works</p>
+      <h1>How C-DAD Works</h1>
+
+      <p>
+        The cdad CLI is the part of Contract-Driven AI Development you
+        actually run. Five commands cover the whole loop. <code>cdad check</code>
+        scores how legible your repo is right now and writes a report.
+        <code>cdad roadmap</code> reads that report and ranks which capabilities
+        are worth extracting first. <code>cdad init</code> scaffolds the contract
+        files for whichever capability you picked. <code>cdad validate</code> keeps
+        those files honest as the code underneath them changes, and
+        <code>cdad graph</code> turns everything you've contracted so far into a
+        dependency map you can actually look at.
+      </p>
+      <p>
+        None of these commands are meant to run once. The intended shape
+        is a loop: check, roadmap, init, validate, graph, then check
+        again, so you can watch the score move as the repo picks up more
+        contracts over time. The pages below cover each command on its
+        own, plus a walkthrough of writing your first contract end to end.
+      </p>
+
+      <ul class="cluster-list">
+        <li>
+          <a href={withBase("/how-c-dad-works/cdad-check/")}>cdad check</a>
+          <p>Scores repo agent-readiness from zero to ten and writes cdad-report.md, the file every later step reads.</p>
+        </li>
+        <li>
+          <a href={withBase("/how-c-dad-works/cdad-roadmap/")}>cdad roadmap</a>
+          <p>Turns the check report into a ranked list of which capabilities to contract first.</p>
+        </li>
+        <li>
+          <a href={withBase("/how-c-dad-works/cdad-init/")}>cdad init</a>
+          <p>Scaffolds the contract triple, yaml, json, and markdown, for a single capability.</p>
+        </li>
+        <li>
+          <a href={withBase("/how-c-dad-works/cdad-validate/")}>cdad validate</a>
+          <p>Checks contract schema, versioning, and generated-artifact consistency before a PR merges.</p>
+        </li>
+        <li>
+          <a href={withBase("/how-c-dad-works/cdad-graph/")}>cdad graph</a>
+          <p>Renders every contracted capability and its dependencies as Mermaid, JSON, and Markdown.</p>
+        </li>
+        <li>
+          <a href={withBase("/how-c-dad-works/writing-your-first-contract/")}>Writing your first contract</a>
+          <p>A full walkthrough of the loop, from a cold repo to a validated, graphed contract.</p>
+        </li>
+      </ul>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/core-model/")}>&larr; The Core Model</a>
+        <a href={withBase("/glossary/")}>Glossary &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .cluster-list {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 1.25rem;
+    margin: 2rem 0;
+  }
+
+  .cluster-list a {
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: var(--border);
+    text-underline-offset: 0.15em;
+  }
+
+  .cluster-list a:hover {
+    color: var(--coral);
+    text-decoration-color: currentColor;
+  }
+
+  .cluster-list p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/how-c-dad-works/cdad-check.astro
+++ b/book-website/src/pages/how-c-dad-works/cdad-check.astro
@@ -1,0 +1,109 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="cdad check"
+  description="cdad check scores how agent-ready your repo is right now, combining a static scan with a short legibility questionnaire, and writes the baseline report every later command reads."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">How C-DAD Works</p>
+      <h1>cdad check</h1>
+
+      <p>
+        <code>cdad check</code> is where the workflow starts. It asks one
+        question about your repository: if an agent had to make a safe
+        change here today, using only what the system makes available,
+        how far would it get? The command answers that by combining two
+        kinds of evidence. First a static scan of the repo itself, then a
+        short questionnaire that walks through up to five capabilities and
+        asks the same four legibility questions for each one. The result
+        is a single score from zero to ten, plus a band that says roughly
+        where the repo sits.
+      </p>
+      <p>
+        The score isn't the point. The report is. Every run writes
+        <code>cdad-report.md</code>, and that file is what <code>cdad roadmap</code>
+        reads next. Skip the check and there's nothing for the roadmap
+        step to prioritize against, so this is genuinely the command
+        everything downstream depends on.
+      </p>
+      <p>
+        A handful of flags let you shape the run. <code>--capabilities &lt;n&gt;</code>
+        changes how many capabilities get walked through the questionnaire,
+        useful if five feels like too many or too few for a first pass.
+        <code>--skip-scan</code> and <code>--skip-questions</code> let you run
+        just one half of the assessment when you already trust the other
+        half. <code>--output &lt;path&gt;</code> moves the report somewhere other
+        than the repo root, and <code>--format json</code> swaps the Markdown
+        report for a machine-readable one if you're feeding the result into
+        other tooling instead of reading it yourself.
+      </p>
+      <p>
+        Run it again later and you get a second data point, not just a
+        second score. Comparing two reports over a few months is the
+        clearest way to see whether the extraction work is actually paying
+        off.
+      </p>
+
+      <pre><code>cdad check
+cdad check --capabilities 8 --format json</code></pre>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/how-c-dad-works/")}>&larr; How C-DAD Works</a>
+        <a href={withBase("/how-c-dad-works/cdad-roadmap/")}>cdad roadmap &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  pre {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 0.5em;
+    padding: 1em 1.25em;
+    overflow-x: auto;
+    margin: 1.5rem 0;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+    font-size: 0.85em;
+    line-height: 1.6;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/how-c-dad-works/cdad-graph.astro
+++ b/book-website/src/pages/how-c-dad-works/cdad-graph.astro
@@ -1,0 +1,109 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="cdad graph"
+  description="cdad graph renders every contracted capability and its dependencies as Mermaid, JSON, and Markdown, so you can see where change propagates and which parts of the repo still need work."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">How C-DAD Works</p>
+      <h1>cdad graph</h1>
+
+      <p>
+        One contract tells you about one capability. What you actually
+        want, once a few of them exist, is to see how they connect. That's
+        what <code>cdad graph</code> does. It walks every contract in the
+        repo and renders the dependency map as three artifacts at once:
+        <code>cdad-graph.mmd</code> as a Mermaid diagram, <code>cdad-graph.json</code>
+        as an adjacency list, and <code>cdad-graph.md</code> as a Markdown
+        summary.
+      </p>
+      <p>
+        Of the three, the JSON adjacency list is the one meant to last.
+        It's deliberately kept stable so other tooling, including an agent
+        deciding whether a change is safe, can consume it without any
+        scraping or parsing tricks. The Mermaid file is for humans, drop
+        it into a doc or a PR description and it renders as an actual
+        diagram. The Markdown file sits in between, readable on its own
+        and still structured enough to skim quickly.
+      </p>
+      <p>
+        You don't have to render the whole repo every time. <code>--capability &lt;id&gt;</code>
+        scopes the graph to one capability and whatever it touches,
+        <code>--domain &lt;name&gt;</code> scopes it to everything under one
+        domain, and <code>--state &lt;state&gt;</code> filters by lifecycle
+        state if you only care about, say, what's still in draft. If you
+        only need one of the three output formats, <code>--no-mermaid</code>
+        and <code>--no-json</code> skip the ones you don't want, and
+        <code>--output &lt;dir&gt;</code> moves the artifacts somewhere other
+        than the default location.
+      </p>
+      <p>
+        This is also the command that makes gaps visible. A capability
+        with no incoming or outgoing edges either genuinely stands alone
+        or hasn't been connected to its neighbors yet, and the graph is
+        usually the fastest way to tell which one is true.
+      </p>
+
+      <pre><code>cdad graph
+cdad graph --domain payments --no-mermaid</code></pre>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/how-c-dad-works/cdad-validate/")}>&larr; cdad validate</a>
+        <a href={withBase("/how-c-dad-works/writing-your-first-contract/")}>Writing your first contract &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  pre {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 0.5em;
+    padding: 1em 1.25em;
+    overflow-x: auto;
+    margin: 1.5rem 0;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+    font-size: 0.85em;
+    line-height: 1.6;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/how-c-dad-works/cdad-init.astro
+++ b/book-website/src/pages/how-c-dad-works/cdad-init.astro
@@ -1,0 +1,109 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="cdad init"
+  description="cdad init scaffolds the contract triple for one capability, yaml, json, and markdown, under cdad in your repo, and can pull straight from the notes your roadmap step already gathered."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">How C-DAD Works</p>
+      <h1>cdad init</h1>
+
+      <p>
+        Once <code>cdad roadmap</code> tells you which capability to contract
+        first, <code>cdad init &lt;capability-id&gt;</code> is what actually
+        creates the files. Run it and you get a contract triple: a
+        <code>contract.yaml</code>, a <code>contract.json</code>, and a
+        <code>contract.md</code>, all written under
+        <code>cdad/&lt;capability-id&gt;/</code>.
+      </p>
+      <p>
+        The capability ID isn't a free-text label. It has to follow the
+        <code>domain/subdomain/action</code> shape, something like
+        <code>payments/retries/schedule-retry</code>, and <code>cdad init</code>
+        validates that shape before it writes anything. That structure is
+        what lets <code>cdad graph</code> later group and connect capabilities
+        sensibly instead of treating every contract as an unrelated island.
+      </p>
+      <p>
+        By default the command prompts you through the basics as it
+        scaffolds, but <code>--no-prompts</code> skips that and writes
+        placeholders instead, handy if you're generating several contracts
+        in a script and plan to fill them in by hand afterward. If the
+        capability needs more than the minimum fields, such as a longer
+        constraint history or a wider set of dependencies, <code>--extended</code>
+        scaffolds the extended template rather than the baseline one.
+        <code>--output &lt;dir&gt;</code> changes the base directory from the
+        default <code>cdad</code> if your repo keeps generated artifacts
+        somewhere else.
+      </p>
+      <p>
+        One detail worth knowing: if you ran <code>cdad roadmap</code> first,
+        <code>cdad init</code> can pull the notes it gathered about that
+        capability straight into the new contract, so the criticality and
+        frequency reasoning you already worked out doesn't have to get
+        retyped from scratch.
+      </p>
+
+      <pre><code>cdad init payments/retries/schedule-retry
+cdad init payments/retries/schedule-retry --extended</code></pre>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/how-c-dad-works/cdad-roadmap/")}>&larr; cdad roadmap</a>
+        <a href={withBase("/how-c-dad-works/cdad-validate/")}>cdad validate &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  pre {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 0.5em;
+    padding: 1em 1.25em;
+    overflow-x: auto;
+    margin: 1.5rem 0;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+    font-size: 0.85em;
+    line-height: 1.6;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/how-c-dad-works/cdad-roadmap.astro
+++ b/book-website/src/pages/how-c-dad-works/cdad-roadmap.astro
@@ -1,0 +1,107 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="cdad roadmap"
+  description="cdad roadmap turns a cdad check report into a ranked list of which capabilities to contract first, weighing criticality, tribal knowledge density, and how often agents actually touch each one."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">How C-DAD Works</p>
+      <h1>cdad roadmap</h1>
+
+      <p>
+        A check report tells you how illegible the repo is. It doesn't
+        tell you where to start fixing that, and with a repo of any real
+        size, "start everywhere" isn't a plan. <code>cdad roadmap</code> is
+        the command that turns a score into an order of operations.
+      </p>
+      <p>
+        It reads <code>cdad-report.md</code>, the file <code>cdad check</code> just
+        wrote, and asks you two more things for each capability the check
+        step covered: how critical is this if it breaks, and how often
+        does it actually get touched. Those two answers get multiplied
+        against a third axis the check step already produced, the tribal
+        knowledge density implied by that capability's legibility score.
+        Criticality times frequency times tribal knowledge density gives
+        you a ranking, not a vibe. The capability at the top of the list
+        is the one where getting it wrong costs the most and a contract
+        would help the most often.
+      </p>
+      <p>
+        The output is <code>cdad-roadmap.md</code>, written next to the
+        report it came from. If you'd rather consume the ranking
+        programmatically, <code>--format json</code> writes it as structured
+        data instead of prose. <code>--input &lt;path&gt;</code> and
+        <code>--output &lt;path&gt;</code> exist for the same reason the check
+        command has them, so the two files don't have to live at the
+        default location if your repo's conventions say otherwise.
+      </p>
+      <p>
+        Whatever sits at the top of the roadmap is what you hand to
+        <code>cdad init</code> next. That's the whole point of ranking it in
+        the first place, so the first capability anyone contracts is
+        the one that was actually worth doing first.
+      </p>
+
+      <pre><code>cdad roadmap
+cdad roadmap --input cdad-report.md --format json</code></pre>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/how-c-dad-works/cdad-check/")}>&larr; cdad check</a>
+        <a href={withBase("/how-c-dad-works/cdad-init/")}>cdad init &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  pre {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 0.5em;
+    padding: 1em 1.25em;
+    overflow-x: auto;
+    margin: 1.5rem 0;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+    font-size: 0.85em;
+    line-height: 1.6;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/how-c-dad-works/cdad-validate.astro
+++ b/book-website/src/pages/how-c-dad-works/cdad-validate.astro
@@ -1,0 +1,108 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="cdad validate"
+  description="cdad validate checks contract schema, versioning rules, and generated-artifact consistency, and can install a pre-commit hook so a stale contract never quietly merges."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">How C-DAD Works</p>
+      <h1>cdad validate</h1>
+
+      <p>
+        A contract is only useful while it's true. The moment the code
+        changes and nobody updates the contract next to it, you're back to
+        documentation that lies, which is arguably worse than no
+        documentation at all. <code>cdad validate &lt;path&gt;</code> is the
+        command that catches that drift before it ships. It checks the
+        contract files against the schema, enforces the versioning rules,
+        and confirms the generated artifacts still match what the contract
+        actually declares.
+      </p>
+      <p>
+        Run it against a single path while you're working on one
+        capability, or add <code>--all</code> to validate every contract in
+        the repo at once, which is what most teams run in CI. <code>--strict</code>
+        turns warnings into errors, so a check that would otherwise pass
+        with a note now fails the build. If a problem has a safe automatic
+        fix, <code>--fix</code> will apply it rather than just flagging it,
+        and <code>--format json</code> gives you machine-readable output if
+        another tool needs to consume the results.
+      </p>
+      <p>
+        The flag worth calling out specifically is <code>--install-hook</code>.
+        It installs a POSIX shell pre-commit hook that runs validation
+        automatically before a commit lands, which is the difference
+        between "we're supposed to validate contracts" and contracts that
+        actually stay validated. Most teams run this once, early, and then
+        forget it's there because it just quietly does its job on every
+        commit.
+      </p>
+      <p>
+        The recommended point to run this by hand is right before a PR:
+        <code>cdad validate --all --strict</code>, so nothing with a stale
+        or malformed contract merges in the first place.
+      </p>
+
+      <pre><code>cdad validate cdad/payments/retries/schedule-retry
+cdad validate --all --strict</code></pre>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/how-c-dad-works/cdad-init/")}>&larr; cdad init</a>
+        <a href={withBase("/how-c-dad-works/cdad-graph/")}>cdad graph &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  pre {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 0.5em;
+    padding: 1em 1.25em;
+    overflow-x: auto;
+    margin: 1.5rem 0;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+    font-size: 0.85em;
+    line-height: 1.6;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/how-c-dad-works/writing-your-first-contract.astro
+++ b/book-website/src/pages/how-c-dad-works/writing-your-first-contract.astro
@@ -1,0 +1,130 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Writing Your First Contract"
+  description="A walkthrough of the cdad workflow end to end: run check, rank with roadmap, scaffold with init, keep it honest with validate, and see it land in graph."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">How C-DAD Works</p>
+      <h1>Writing Your First Contract</h1>
+
+      <p>
+        The five commands make more sense as a sequence than as a
+        reference list, so here's what running them actually looks like
+        on a repo that has never seen cdad before.
+      </p>
+      <p>
+        Start in the repo root with <code>cdad check</code>. It runs its
+        static scan, then walks you through the legibility questionnaire
+        for a handful of capabilities it found, four questions each. A
+        couple of minutes later you have a score, a band, and
+        <code>cdad-report.md</code> sitting in the repo. Don't worry if the
+        score is low. A low score is just an accurate starting point, and
+        most first runs land somewhere in the middle.
+      </p>
+      <p>
+        Next, <code>cdad roadmap</code>. It reads that same report and asks
+        two more questions per capability: how critical is it, and how
+        often does it actually get touched. Multiply those against the
+        tribal knowledge density the check step already surfaced and you
+        get a ranked list in <code>cdad-roadmap.md</code>. Whatever lands at
+        the top is usually the capability where nobody quite remembers why
+        a certain edge case exists, which is exactly the kind of thing
+        worth writing down before it's forgotten entirely.
+      </p>
+      <p>
+        Take that top capability and hand its ID to <code>cdad init</code>.
+        If it's <code>payments/retries/schedule-retry</code>, that's what you
+        type, and the command scaffolds <code>contract.yaml</code>,
+        <code>contract.json</code>, and <code>contract.md</code> under
+        <code>cdad/payments/retries/schedule-retry/</code>, prompting you for
+        the details as it goes. This is where you write down what the
+        capability actually promises, what it needs to run, and just as
+        important, what it deliberately doesn't do. That last part is
+        often the piece nobody's written down anywhere else.
+      </p>
+      <p>
+        Before you commit any of it, run <code>cdad validate --all --strict</code>.
+        It checks the schema, the versioning, and whether the generated
+        files still line up with the contract itself. If this is your
+        first contract in the repo, it's also worth running
+        <code>cdad validate --install-hook</code> once, so every commit after
+        this one gets checked automatically instead of relying on someone
+        remembering to run it by hand.
+      </p>
+      <p>
+        Finally, <code>cdad graph</code>. On a repo with exactly one
+        contract, the graph won't look like much yet, and that's fine.
+        The value shows up as more contracts get added and you can
+        actually see how <code>payments/retries/schedule-retry</code> connects
+        to whatever calls it. Run <code>cdad check</code> again down the
+        road and you'll have a second score to compare against the first,
+        which is the real measure of whether any of this was worth doing.
+      </p>
+
+      <pre><code>cdad check
+cdad roadmap
+cdad init payments/retries/schedule-retry
+cdad validate --all --strict
+cdad graph</code></pre>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/how-c-dad-works/cdad-graph/")}>&larr; cdad graph</a>
+        <a href={withBase("/how-c-dad-works/")}>How C-DAD Works &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  pre {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 0.5em;
+    padding: 1em 1.25em;
+    overflow-x: auto;
+    margin: 1.5rem 0;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+    font-size: 0.85em;
+    line-height: 1.6;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/index.astro
+++ b/book-website/src/pages/index.astro
@@ -8,55 +8,55 @@ import AudienceGrid from "../components/AudienceGrid.astro";
 import BuyLinks from "../components/BuyLinks.astro";
 import { withBase } from "../utils/url";
 
-// Section copy is written from the book's own manuscript (Chapters 1–5),
-// kept to non-spoiler summary and thesis statements — no plot points or
+// Section copy is written from the book's own manuscript (Chapters 1-5),
+// kept to non-spoiler summary and thesis statements, no plot points or
 // worked examples from the text itself.
 const tribalKnowledgeCopy = [
-  "Every software organization has the same hidden liability: the reasoning behind its own decisions lives in people's heads, in Slack threads that decay within months, in commit messages that record what changed but never why. AI agents can read an entire codebase in seconds — they can't ask a senior engineer what a payment constraint actually means, or why a service calls another out of the “obvious” order.",
-  "That gap isn't a documentation problem you can wiki your way out of. It's structural. The knowledge that keeps a system safe was never designed to be found by anything that can't tap someone on the shoulder — and every constraint that exists only in someone's memory is a constraint an agent will walk straight past.",
-  "The Day After opens on a single incident: a clean, fast, technically correct AI-generated change that breaks production hours later — not because the agent did anything wrong, but because the system never told it what it needed to know. It's the pattern already playing out on every team pointing agents at a real codebase, and it's where the book begins.",
+  "Every software organization has the same hidden liability: the reasoning behind its own decisions lives in people's heads, in Slack threads that decay within months, in commit messages that record what changed but never why. AI agents can read an entire codebase in seconds, but they can't ask a senior engineer what a payment constraint actually means, or why a service calls another out of the “obvious” order.",
+  "That gap isn't a documentation problem you can wiki your way out of. It's structural. The knowledge that keeps a system safe was never designed to be found by anything that can't tap someone on the shoulder, and every constraint that exists only in someone's memory is a constraint an agent will walk straight past.",
+  "The Day After opens on a single incident: a clean, fast, technically correct AI-generated change that breaks production hours later, not because the agent did anything wrong, but because the system never told it what it needed to know. It's the pattern already playing out on every team pointing agents at a real codebase, and it's where the book begins.",
 ];
 
 const tribalKnowledgeCards = [
-  { title: "The Onboarding Tax", body: "New hires spend weeks reconstructing context that already existed — just nowhere they could find it." },
+  { title: "The Onboarding Tax", body: "New hires spend weeks reconstructing context that already existed, just nowhere they could find it." },
   { title: "The Departure Risk", body: "When a senior engineer leaves, years of undeclared context leave with them." },
-  { title: "The Agent Blind Spot", body: "Coding agents read your files, not your Slack history — so tribal knowledge is invisible to exactly the tool you're betting on." },
+  { title: "The Agent Blind Spot", body: "Coding agents read your files, not your Slack history, so tribal knowledge is invisible to exactly the tool you're betting on." },
 ];
 
 const contractsCopy = [
-  "Contracts aren't more documentation, and they aren't a better wiki. A contract is a structured, machine-readable declaration of what a piece of business logic does, why it does it, and what would break if it changed — written once, in a form both humans and agents can act on.",
-  "Every fix teams normally reach for — documentation sprints, tighter prompts, more supervision — treats the symptom. Each one makes an illegible system slightly less illegible for a while. None of them change the underlying condition: the system still doesn't declare what it knows.",
+  "Contracts aren't more documentation, and they aren't a better wiki. A contract is a structured, machine-readable declaration of what a piece of business logic does, why it does it, and what would break if it changed, written once, in a form both humans and agents can act on.",
+  "Every fix teams normally reach for, documentation sprints, tighter prompts, more supervision, treats the symptom. Each one makes an illegible system slightly less illegible for a while. None of them change the underlying condition: the system still doesn't declare what it knows.",
   "Chapter 3 makes the case for contracts as the structural fix, not a documentation exercise: what a contract has to capture, and why “good enough” documentation was never going to be enough for agents that can't ask a follow-up question.",
 ];
 
 const contractsCards = [
-  { title: "Not Documentation", body: "A wiki page describes a system. A contract declares it — in a form an agent can act on without a human translating first." },
+  { title: "Not Documentation", body: "A wiki page describes a system. A contract declares it, in a form an agent can act on without a human translating first." },
   { title: "Machine-Readable", body: "Contracts are structured enough for an agent to parse, and specific enough for a human to trust." },
-  { title: "Built to Survive Turnover", body: "Contracts outlive the engineer who wrote them — the way a Slack thread never does." },
+  { title: "Built to Survive Turnover", body: "Contracts outlive the engineer who wrote them, the way a Slack thread never does." },
 ];
 
 const capabilitiesCopy = [
-  "Contracts describe individual pieces of logic. The capabilities graph is what happens when you connect them: a map of every capability in a system, its dependencies, its owner, and the contract that governs it — legible to a new hire and an AI agent in exactly the same way.",
-  "Chapter 4 introduces the capability as a new atomic unit of software design: headless, portable, and contract-defined — a different way of decomposing a system than the service boundaries most teams already have.",
-  "The result isn't a diagram for a slide deck. It's a structure a coding agent can actually navigate — the difference between an agent guessing at your architecture and an agent reading it.",
+  "Contracts describe individual pieces of logic. The capabilities graph is what happens when you connect them: a map of every capability in a system, its dependencies, its owner, and the contract that governs it, legible to a new hire and an AI agent in exactly the same way.",
+  "Chapter 4 introduces the capability as a new atomic unit of software design: headless, portable, and contract-defined, a different way of decomposing a system than the service boundaries most teams already have.",
+  "The result isn't a diagram for a slide deck. It's a structure a coding agent can actually navigate, the difference between an agent guessing at your architecture and an agent reading it.",
 ];
 
 const capabilitiesCards = [
-  { title: "Headless", body: "A capability doesn't know or care how it's presented — no UI assumptions baked into the logic." },
+  { title: "Headless", body: "A capability doesn't know or care how it's presented, no UI assumptions baked into the logic." },
   { title: "Portable", body: "The same capability runs wherever it's called from, without dragging its old service along." },
-  { title: "Contract-Defined", body: "Every capability's boundaries, dependencies, and rules are declared — not inferred from reading the code." },
+  { title: "Contract-Defined", body: "Every capability's boundaries, dependencies, and rules are declared, not inferred from reading the code." },
 ];
 
 const extractionCopy = [
   "The instinctive response to an illegible codebase is a refactor. Chapter 5 argues that's the expensive trap: a months-long cleanup that consumes an organization's most senior engineers and, at the end, produces cleaner code that still can't explain itself to an agent.",
-  "Refactoring makes code easier to read. It doesn't make a system declare what it knows — and legibility is a property of declared contracts, not clean code. An agent pointed at a beautifully refactored system fails for the exact same reasons it failed before.",
-  "Extraction is the alternative this chapter lays out: pull capabilities out of the legacy system one at a time, contract them properly, and leave the rest of the codebase untouched until it's its turn — progress that compounds instead of a rewrite that has to finish before it pays off.",
+  "Refactoring makes code easier to read. It doesn't make a system declare what it knows, and legibility is a property of declared contracts, not clean code. An agent pointed at a beautifully refactored system fails for the exact same reasons it failed before.",
+  "Extraction is the alternative this chapter lays out: pull capabilities out of the legacy system one at a time, contract them properly, and leave the rest of the codebase untouched until it's its turn, progress that compounds instead of a rewrite that has to finish before it pays off.",
 ];
 
 const extractionCards = [
   { title: "Code Is Cheap", body: "Rewriting a service is the easy part. Capturing why it works the way it does is what refactors skip." },
-  { title: "Ship the Slice", body: "Extract one capability, contract it, move on — value lands after the first slice, not after the whole system is done." },
-  { title: "Senior Time, Spent Once", body: "The knowledge in your senior engineers' heads gets captured in the contract — not burned re-implementing what already worked." },
+  { title: "Ship the Slice", body: "Extract one capability, contract it, move on, value lands after the first slice, not after the whole system is done." },
+  { title: "Senior Time, Spent Once", body: "The knowledge in your senior engineers' heads gets captured in the contract, not burned re-implementing what already worked." },
 ];
 
 // Sunrise sequence, first to last. Drop extra frames (e.g. a dawn shot)
@@ -194,8 +194,8 @@ const heroTiming = `
 
   <section class="section quote">
     <div class="wrap">
-      <!-- Pull-quote from the book itself (Ch. 1) — no reader testimonials
-           exist yet; swap this for a real endorsement once one does. -->
+      <!-- Pull-quote from the book itself (Ch. 1), no reader testimonials
+           exist yet. Swap this for a real endorsement once one does. -->
       <p class="quote__text">"A system that cannot make its intent legible to an AI agent is a system that will be navigated by competitors who can."</p>
       <hr class="divider quote__divider" />
     </div>
@@ -204,7 +204,7 @@ const heroTiming = `
   <section class="cta">
     <div class="wrap">
       <h2>Get the book.</h2>
-      <p class="cta__subtitle">A concrete recipe for every role in a software organization — read the opening chapter free.</p>
+      <p class="cta__subtitle">A concrete recipe for every role in a software organization, read the opening chapter free.</p>
       <BuyLinks />
     </div>
   </section>
@@ -269,7 +269,7 @@ const heroTiming = `
      blurred and enlarged so the blur's own soft edge never shows, sitting
      behind the hero and bleeding a little past its edges. It cross-fades
      night-to-day on the same schedule as the sharp images (same keyframe,
-     same delays), just softened and kept faint — real photo color (night
+     same delays), just softened and kept faint. Real photo color (night
      blue warming to sunrise gold), not a synthetic tint. */
   .hero__ambient {
     position: absolute;

--- a/book-website/src/pages/proof.astro
+++ b/book-website/src/pages/proof.astro
@@ -1,0 +1,103 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="Proof"
+  description="Contract-Driven AI Development isn't just an argument. It's a scoring methodology you can run, a priority model you can check, and a CLI you can read line by line."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Proof</p>
+      <h1>Proof</h1>
+
+      <p>
+        Most of this site makes a case: tribal knowledge is a bottleneck,
+        contracts fix it, and the fix compounds. A case is only worth as
+        much as the mechanics underneath it, so this section is where those
+        mechanics get shown rather than asserted. How does a legibility
+        score actually get computed. Why does extraction beat a rewrite on
+        the math, not just on vibes. What happens when you go look at the
+        toolkit's source instead of taking a claim about it on faith.
+      </p>
+      <p>
+        None of the three pages below ask you to trust a metaphor. They
+        walk through the scoring rules, the extraction priority logic, and
+        the fact that the CLI and its schemas are sitting in the open where
+        anyone can read them.
+      </p>
+
+      <ul class="cluster-list">
+        <li>
+          <a href={withBase("/proof/legibility-scoring-methodology/")}>Legibility Scoring Methodology</a>
+          <p>How four questions and a half-point scale turn "this code feels risky" into an actual number.</p>
+        </li>
+        <li>
+          <a href={withBase("/proof/case-for-extraction-over-rewrite/")}>The Case for Extraction Over Rewrite</a>
+          <p>Why a rewrite spends senior engineering time on cleaner code that still doesn't declare what it knows.</p>
+        </li>
+        <li>
+          <a href={withBase("/proof/open-source-toolkit/")}>Open Source Toolkit</a>
+          <p>The CLI, the schemas, and the validation logic are public, so the methodology isn't a marketing claim.</p>
+        </li>
+      </ul>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/use-cases/")}>&larr; Use Cases</a>
+        <a href={withBase("/examples/")}>Examples &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .cluster-list {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 1.25rem;
+    margin: 2rem 0;
+  }
+
+  .cluster-list a {
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: var(--border);
+    text-underline-offset: 0.15em;
+  }
+
+  .cluster-list a:hover {
+    color: var(--coral);
+    text-decoration-color: currentColor;
+  }
+
+  .cluster-list p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/proof/case-for-extraction-over-rewrite.astro
+++ b/book-website/src/pages/proof/case-for-extraction-over-rewrite.astro
@@ -1,0 +1,95 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="The Case for Extraction Over Rewrite"
+  description="A rewrite spends senior engineering time and produces cleaner code that still doesn't declare what it knows. Extraction produces incremental value that compounds instead."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Proof</p>
+      <h1>The Case for Extraction Over Rewrite</h1>
+
+      <p>
+        The instinct when a codebase feels illegible is to rewrite it.
+        Clear it out, start clean, do it properly this time. Chapter 5
+        argues that instinct is usually wrong, and not for sentimental
+        reasons. A rewrite consumes months of your most senior engineers'
+        time, and at the end of it you have cleaner code that still
+        doesn't declare why it works the way it does. The tribal knowledge
+        that made the old system risky just moves into the new one,
+        unwritten, waiting for the next person who has to guess at it.
+      </p>
+      <p>
+        Extraction is a different bet. Instead of replacing a system, you
+        pull one capability at a time into a contract that says what it
+        does, what it needs, what it promises, and what it explicitly
+        doesn't do. Each extraction ships independently, each one is
+        immediately useful on its own, and the value compounds as the
+        capability graph fills in. A rewrite pays off once, if it pays off
+        at all. Extraction pays off capability by capability, starting
+        with the first one you finish.
+      </p>
+      <p>
+        The harder question is which capability to extract first, and
+        that's where the priority model earns its keep. Three axes decide
+        it: business criticality, how much revenue or compliance risk
+        actually sits inside the capability, tribal knowledge density,
+        pulled straight from the legibility audit score, and agent
+        touchpoint frequency, how often agents are actually going to work
+        inside this capability once they're operating in the system.
+      </p>
+      <p>
+        Those three axes get multiplied, never added. That choice matters
+        more than it looks. A capability that's mission-critical and
+        completely opaque but that nobody, human or agent, ever touches
+        shouldn't jump the queue ahead of one that's moderately risky and
+        gets hit constantly. Multiplying keeps a zero on any single axis
+        from letting a capability sneak to the front, because a zero
+        anywhere means it isn't a real candidate yet, no matter how bad the
+        other two numbers look.
+      </p>
+      <p>
+        The result sorts into three phases. A perfect score of nine lands
+        in phase one: extract now. Scores from four to eight are phase two:
+        next in line. Scores of one to three are phase three: worth
+        tracking, not urgent. A score of zero means the capability isn't a
+        current extraction candidate at all, and knowing that is useful too.
+        Not everything needs a contract on day one, and pretending
+        otherwise is how extraction programs stall under their own scope.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/proof/legibility-scoring-methodology/")}>&larr; Legibility Scoring Methodology</a>
+        <a href={withBase("/proof/open-source-toolkit/")}>Open Source Toolkit &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/proof/legibility-scoring-methodology.astro
+++ b/book-website/src/pages/proof/legibility-scoring-methodology.astro
@@ -1,0 +1,97 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Legibility Scoring Methodology"
+  description="One diagnostic question, broken into four scored sub-questions, run against real capabilities. This is how the toolkit turns a gut feeling about risky code into a number."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Proof</p>
+      <h1>Legibility Scoring Methodology</h1>
+
+      <p>
+        The whole audit reduces to one diagnostic question. Could a capable
+        engineer, with no tribal knowledge and no history with your team,
+        safely change this capability using only what the system makes
+        available to them? Everything else is just that question broken
+        into pieces small enough to score.
+      </p>
+      <p>
+        There are four sub-questions underneath it. Can someone tell why
+        the capability works this way, not only what it currently does.
+        Can they see what was tried before and why it didn't stick. Can
+        they understand why it calls what it calls instead of the more
+        obvious alternative sitting right next to it. And can they find
+        every exception path that traces back to a specific customer, a
+        regulation, or an incident from a few years ago that nobody wrote
+        down.
+      </p>
+      <p>
+        Scoring is deliberately plain. A full point when the answer is
+        clearly yes, half a point when the answer is partial, zero when
+        there's nothing there but tribal memory. No weighting tricks, no
+        hidden multipliers at this stage. The scale stays legible on
+        purpose, because a scoring method nobody can audit by hand isn't
+        much of an improvement over the guesswork it replaces.
+      </p>
+      <p>
+        <code>cdad check</code> is where this methodology actually runs. It
+        combines a static scan of the repository with a short questionnaire
+        that walks through up to five capabilities and asks the same four
+        questions for each one, then rolls the result into a single score
+        from zero to ten with a band attached, written to
+        <code>cdad-report.md</code>. The methodology isn't hidden behind the
+        tool. It's the same four questions every time, just automated
+        enough that running it twice a quarter is realistic.
+      </p>
+      <p>
+        Low scores aren't a verdict on the engineers who built the
+        capability. They're a map of where tribal knowledge is doing the
+        most load-bearing work, and therefore where an agent, or a new
+        hire, is most likely to walk into something nobody thought to
+        write down.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/proof/")}>&larr; Proof</a>
+        <a href={withBase("/proof/case-for-extraction-over-rewrite/")}>The Case for Extraction Over Rewrite &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/proof/open-source-toolkit.astro
+++ b/book-website/src/pages/proof/open-source-toolkit.astro
@@ -1,0 +1,91 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Open Source Toolkit"
+  description="The CLI, the contract schemas, and the validation logic behind Contract-Driven AI Development are public. You don't have to take the methodology on faith when you can read the code."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Proof</p>
+      <h1>Open Source Toolkit</h1>
+
+      <p>
+        Everything described elsewhere on this site, the scoring
+        methodology, the extraction priority model, the shape of a
+        contract, is backed by a real, runnable command-line tool, and that
+        tool is open source. That's not a footnote. It's the difference
+        between a framework you have to trust and one you can go verify
+        yourself, field by field.
+      </p>
+      <p>
+        The <code>cdad</code> CLI implements <code>check</code>,
+        <code>roadmap</code>, <code>init</code>, <code>validate</code>, and
+        <code>graph</code> as five real commands with real output files,
+        not five slide-deck labels. The contract schemas that
+        <code>init</code> scaffolds and <code>validate</code> checks against
+        live in the same repository as the code that reads them. If you
+        want to know exactly what makes a contract pass validation, or
+        exactly how the legibility questionnaire turns answers into a
+        score, the answer isn't a claim on this page. It's a file you can
+        open.
+      </p>
+      <p>
+        That matters most for the parts of the methodology that are easiest
+        to be skeptical about from a distance. Multiplying three axes
+        instead of adding them, scoring half-points on partial answers,
+        deciding what counts as an exception path worth flagging. None of
+        that is arbitrary once you can see the logic that implements it,
+        and none of it is hidden behind a paywall or a sales call to check.
+      </p>
+      <p>
+        The toolkit being public also means it's inspectable by the exact
+        audience it's built for. An engineer deciding whether to adopt this
+        in their own repository doesn't need to trust a vendor's pitch.
+        They can read the schemas, run the CLI against a real repo, and
+        judge the output on its own terms before committing a single
+        capability to it.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/proof/case-for-extraction-over-rewrite/")}>&larr; The Case for Extraction Over Rewrite</a>
+        <a href={withBase("/proof/")}>Proof overview &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/the-day-after.astro
+++ b/book-website/src/pages/the-day-after.astro
@@ -1,0 +1,79 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="The Day After"
+  description="The developer did everything right. The agent did everything right. The system failed them both. Chapter 1 names the structural shift behind that failure, and why it's not a tooling problem."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Chapter 1 &middot; Part I: The Problem</p>
+      <h1>The Day After</h1>
+
+      <p>
+        The developer did everything right. The agent did everything right.
+        The system failed them both. That's not an edge case or an
+        early-adopter growing pain. It's the pattern showing up on every
+        team that has pointed an AI agent at a real codebase and waited for
+        a productivity gain that never fully arrived. The agent generated
+        code. The code compiled. The code passed the linter. Then it failed
+        in staging because the constraint it broke didn't exist anywhere in
+        the repository. It lived in the memory of a developer who left, in
+        a Slack thread from three years back, in a decision that got made
+        in a meeting and never written down.
+      </p>
+      <p>
+        Most organizations are treating this as a tooling problem. They're
+        adjusting prompts, switching agents, widening context windows,
+        hiring prompt engineers. Chapter 1 argues the diagnosis is wrong.
+        The problem isn't the agent. It's the system the agent has been
+        asked to work inside, a system that was never designed to be
+        navigated by anything that couldn't just ask a person for help.
+        Humans have always been able to compensate for a confusing codebase
+        by talking to each other. Agents can't do that. So every gap in
+        what the system makes legible, every piece of knowledge that never
+        got written down, becomes something an agent runs straight into.
+      </p>
+      <p>
+        This is the chapter that names the shift and lays out the
+        competitive map forming around it. Some companies are already
+        pulling ahead because they understood what actually changed.
+        Others are still tuning their prompts, solving a problem that isn't
+        the one in front of them. What separates those two groups is the
+        subject of everything that follows.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Chapter navigation">
+        <a href={withBase("/about-the-book/")}>&larr; Table of contents</a>
+        <a href={withBase("/tribal-knowledge/")}>Chapter 2: Tribal Knowledge Is the Bottleneck &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/toolkit.astro
+++ b/book-website/src/pages/toolkit.astro
@@ -1,0 +1,111 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="Toolkit"
+  description="cdad is the open source CLI behind Contract-Driven AI Development. Install it, run it against a repository, and it turns the book's methodology into commands you can actually run."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Toolkit</p>
+      <h1>Toolkit</h1>
+
+      <p>
+        The book describes a methodology. The toolkit is what makes it
+        runnable. <code>cdad</code> is an open source command-line tool you
+        install and point at a repository, and it carries the whole
+        adoption loop, from a first legibility check through prioritizing
+        what to extract, scaffolding contracts, validating them, and
+        mapping how they connect.
+      </p>
+      <p>
+        This section covers the practical side of adopting it: how to get
+        it installed and run your first command, a shorter tour of all
+        five commands in one place, and where to go to check the source
+        itself. If you want the deep, one-command-per-page treatment,
+        that lives under <a href={withBase("/how-c-dad-works/")}>How C-DAD Works</a>.
+      </p>
+
+      <ul class="cluster-list">
+        <li>
+          <a href={withBase("/toolkit/installation/")}>Installation</a>
+          <p>Getting the CLI installed and running your first command against a real repository.</p>
+        </li>
+        <li>
+          <a href={withBase("/toolkit/cli-reference/")}>CLI Reference</a>
+          <p>All five commands, check, roadmap, init, validate, and graph, covered in one place.</p>
+        </li>
+        <li>
+          <a href={withBase("/toolkit/github-repository/")}>GitHub Repository</a>
+          <p>Where the schemas, the CLI source, and the documentation actually live.</p>
+        </li>
+      </ul>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/examples/")}>&larr; Examples</a>
+        <a href={withBase("/faq/")}>FAQ &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .cluster-list {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 1.25rem;
+    margin: 2rem 0;
+  }
+
+  .cluster-list a {
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: var(--border);
+    text-underline-offset: 0.15em;
+  }
+
+  .cluster-list a:hover {
+    color: var(--coral);
+    text-decoration-color: currentColor;
+  }
+
+  .cluster-list p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/toolkit/cli-reference.astro
+++ b/book-website/src/pages/toolkit/cli-reference.astro
@@ -1,0 +1,105 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="CLI Reference"
+  description="A quick tour of all five cdad commands, check, roadmap, init, validate, and graph, in one place. For the deeper walkthrough of each one, see How C-DAD Works."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Toolkit</p>
+      <h1>CLI Reference</h1>
+
+      <p>
+        Five commands cover the full loop. This page is the quick version
+        of each. For a longer walkthrough of any single command, including
+        flags and sample output, the dedicated pages under
+        <a href={withBase("/how-c-dad-works/")}>How C-DAD Works</a> go
+        deeper than what's here.
+      </p>
+      <p>
+        <code>cdad check</code> establishes the baseline. It combines a
+        static scan of the repository with a short legibility
+        questionnaire covering up to five capabilities, then writes a
+        score from zero to ten, with a band, to <code>cdad-report.md</code>.
+        Everything else in the loop starts from this file.
+      </p>
+      <p>
+        <code>cdad roadmap</code> reads that report and prioritizes.
+        It factors in business criticality and touchpoint frequency
+        alongside the tribal knowledge density the check already
+        surfaced, multiplies the three together, and writes a ranked
+        list to <code>cdad-roadmap.md</code>.
+      </p>
+      <p>
+        <code>cdad init &lt;capability-id&gt;</code> scaffolds a contract.
+        Given a capability ID in <code>domain/subdomain/action</code> form,
+        it creates the contract triple, YAML, JSON, and Markdown, under
+        <code>cdad/</code>, and can pull relevant notes straight from the
+        roadmap into the new contract.
+      </p>
+      <p>
+        <code>cdad validate &lt;path&gt;</code> keeps contracts honest over
+        time. It checks schema conformance, versioning rules, and whether
+        the generated JSON and Markdown artifacts still match the YAML
+        source of truth. Run it with <code>--all</code> across the whole
+        repo, <code>--strict</code> to treat warnings as failures, or
+        <code>--install-hook</code> to run it automatically before every
+        commit.
+      </p>
+      <p>
+        <code>cdad graph</code> renders every contracted capability and
+        its dependencies as Mermaid, JSON, and Markdown output at once. The
+        JSON adjacency list is the stable, agent-consumable format if
+        you're building anything on top of the graph rather than just
+        looking at it.
+      </p>
+      <p>
+        Put together, the recommended pattern is check, roadmap, init,
+        validate, graph, and then check again once the work has landed, so
+        the score becomes a trend you can watch instead of a single
+        snapshot.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/toolkit/installation/")}>&larr; Installation</a>
+        <a href={withBase("/toolkit/github-repository/")}>GitHub Repository &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/toolkit/github-repository.astro
+++ b/book-website/src/pages/toolkit/github-repository.astro
@@ -1,0 +1,85 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="GitHub Repository"
+  description="The cdad CLI, its contract schemas, and its documentation are open source. The companion GitHub repository is where to check the current source instead of taking this site's word for it."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Toolkit</p>
+      <h1>GitHub Repository</h1>
+
+      <p>
+        Everything this site says about the CLI, the commands, the
+        contract schemas, the validation rules, is backed by real,
+        published source. The toolkit lives in the companion GitHub
+        repository, out in the open, where anyone evaluating it can read
+        the code instead of relying on a description of it.
+      </p>
+      <p>
+        That's where the current, authoritative version of everything
+        lives. The contract schemas that <code>cdad init</code> scaffolds
+        and <code>cdad validate</code> checks against. The CLI source
+        itself, command by command. The documentation covering concepts,
+        anti-patterns, the full command reference, and the adoption
+        journey this site's toolkit pages summarize. Pages here aim to
+        stay accurate to that source, but the repository is the one that
+        updates first when the tool changes.
+      </p>
+      <p>
+        If you're deciding whether to adopt this in your own repository,
+        that's the right place to look before committing anything. Read
+        the schemas, read the validation logic, try the CLI against a
+        throwaway repo if you want to see the output shape before running
+        it somewhere that matters.
+      </p>
+      <p>
+        For an overview of what the toolkit actually does before you go
+        digging through source, start with the
+        <a href={withBase("/toolkit/")}>toolkit overview</a> and work
+        outward from there.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/toolkit/cli-reference/")}>&larr; CLI Reference</a>
+        <a href={withBase("/toolkit/")}>Toolkit overview &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/toolkit/installation.astro
+++ b/book-website/src/pages/toolkit/installation.astro
@@ -1,0 +1,94 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Installation"
+  description="cdad is a CLI you install and run against a repository. Here's the shape of getting started, from installing the tool to running your first check."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Toolkit</p>
+      <h1>Installation</h1>
+
+      <p>
+        <code>cdad</code> is a command-line tool, not a service you sign up
+        for or a platform you migrate onto. You install it, you point it at
+        a repository, and it runs locally against the code that's already
+        there. There's no account to create and nothing to upload before
+        you can see what it does.
+      </p>
+      <p>
+        The practical starting point is to install the CLI from the
+        companion repository, following whatever install instructions are
+        published there for your environment, and confirm it's on your
+        path. From there, adoption doesn't require a plan or a kickoff
+        meeting. It requires one command.
+      </p>
+      <p>
+        Run <code>cdad check</code> in the root of the repository you want
+        to assess. That's the first command in the adoption loop for a
+        reason: it establishes a baseline before you've changed anything,
+        combining a static scan of the repo with a short questionnaire
+        about a handful of real capabilities, and writes the result to
+        <code>cdad-report.md</code>. Nothing about that first run commits
+        you to a full extraction program. It just tells you, honestly,
+        where the repo currently sits.
+      </p>
+      <p>
+        From that first report, the rest of the workflow follows in order,
+        <code>cdad roadmap</code> to prioritize, <code>cdad init</code> to
+        scaffold a contract, <code>cdad validate</code> to keep it honest,
+        and <code>cdad graph</code> to see how it connects to everything
+        else. None of those later steps require reinstalling anything or
+        reconfiguring the tool. The same CLI you installed for the first
+        check carries the whole loop.
+      </p>
+      <p>
+        If you're evaluating whether this fits your stack before
+        installing anything, the CLI reference and the repository itself
+        are the places to look. Both describe exactly what the tool does
+        without asking you to take it on faith first.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/toolkit/")}>&larr; Toolkit</a>
+        <a href={withBase("/toolkit/cli-reference/")}>CLI Reference &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/tribal-knowledge.astro
+++ b/book-website/src/pages/tribal-knowledge.astro
@@ -6,7 +6,7 @@ import { withBase } from "../utils/url";
 
 <BaseLayout
   title="Tribal Knowledge Is the Bottleneck"
-  description="Why the knowledge that keeps your systems safe lives in people's heads instead of your code — and why that's the real reason AI coding agents can't be trusted with it yet."
+  description="Why the knowledge that keeps your systems safe lives in people's heads instead of your code, and why that's the real reason AI coding agents can't be trusted with it yet."
 >
   <section class="section">
     <div class="wrap">
@@ -22,7 +22,7 @@ import { withBase } from "../utils/url";
         lives in someone's head.
       </p>
       <p>
-        Chapter 2 opens on a routine onboarding conversation &mdash; a new
+        Chapter 2 opens on a routine onboarding conversation: a new
         hire, a short list of components to understand, and an engineer
         walking through constraints that exist nowhere else: not in the
         wiki, not in a comment, not in a ticket. Just memory, passed down one
@@ -31,15 +31,15 @@ import { withBase } from "../utils/url";
       </p>
       <p>
         That's the condition AI agents inherit when you point them at a real
-        codebase. An agent can read every file in a repository in seconds
-        &mdash; it cannot sit in on that onboarding conversation. Every
+        codebase. An agent can read every file in a repository in seconds,
+        but it cannot sit in on that onboarding conversation. Every
         constraint that only exists in someone's memory is invisible to
         exactly the tool teams are now betting production changes on.
       </p>
       <p>
-        The chapter maps where this knowledge actually lives &mdash; Slack
+        The chapter maps where this knowledge actually lives, in Slack
         threads, tribal shorthand, the specific developers who've "just
-        always known" &mdash; and makes the case that this isn't a
+        always known," and makes the case that this isn't a
         documentation gap you can wiki your way out of. It's a structural
         condition with a structural cost, and naming it precisely is where
         the fix starts.
@@ -49,7 +49,7 @@ import { withBase } from "../utils/url";
 
       <nav class="chapter-nav" aria-label="Chapter navigation">
         <a href={withBase("/about-the-book/")}>&larr; Table of contents</a>
-        <a href={withBase("/contracts/")}>Chapter 3 &mdash; Contracts Are the Answer &rarr;</a>
+        <a href={withBase("/contracts/")}>Chapter 3: Contracts Are the Answer &rarr;</a>
       </nav>
     </div>
   </section>

--- a/book-website/src/pages/use-cases.astro
+++ b/book-website/src/pages/use-cases.astro
@@ -1,0 +1,113 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import BuyLinks from "../components/BuyLinks.astro";
+import { withBase } from "../utils/url";
+---
+
+<BaseLayout
+  title="Use Cases"
+  description="Five situations where a legibility gap causes real damage: legacy modernization, onboarding, preparing for AI agents, microservices with no single owner, and regulated industries with exception paths nobody tracks."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Use Cases</p>
+      <h1>Use Cases</h1>
+
+      <p>
+        The idea behind C-DAD is general enough to sound abstract until you
+        see it against a specific situation. This section covers five of
+        them: a team inheriting a legacy system, a new engineer trying to
+        get productive without bothering six people a day, an organization
+        about to point AI agents at production code, a set of
+        microservices that outgrew any one person's understanding, and a
+        team operating under regulatory constraints that live in nobody's
+        head but the people who were there when the rule got added.
+      </p>
+      <p>
+        None of these are hypothetical categories invented to sell a
+        toolkit. They're the recurring shapes that show up whenever a
+        system gets old enough, or big enough, or regulated enough, that
+        the knowledge required to change it safely stops fitting inside
+        any one person's head.
+      </p>
+
+      <ul class="cluster-list">
+        <li>
+          <a href={withBase("/use-cases/legacy-codebase-modernization/")}>Legacy Codebase Modernization</a>
+          <p>Making an old system safe to extend without betting a quarter on a rewrite that might not even fix the real problem.</p>
+        </li>
+        <li>
+          <a href={withBase("/use-cases/onboarding-new-engineers/")}>Onboarding New Engineers</a>
+          <p>Replacing weeks of tribal-knowledge reconstruction with a contract a new hire can actually read.</p>
+        </li>
+        <li>
+          <a href={withBase("/use-cases/preparing-for-ai-coding-agents/")}>Preparing for AI Coding Agents</a>
+          <p>Why legibility has to come before you point an agent at a codebase, not after something breaks.</p>
+        </li>
+        <li>
+          <a href={withBase("/use-cases/microservices-with-many-owners/")}>Microservices with Many Owners</a>
+          <p>A capability graph as the shared map for a system no single team understands end to end.</p>
+        </li>
+        <li>
+          <a href={withBase("/use-cases/regulated-industries-and-compliance/")}>Regulated Industries and Compliance</a>
+          <p>Declaring the exception paths a regulator, a customer, or an old incident actually requires.</p>
+        </li>
+      </ul>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/comparisons/")}>&larr; Comparisons</a>
+        <a href={withBase("/proof/")}>Proof &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .cluster-list {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 1.25rem;
+    margin: 2rem 0;
+  }
+
+  .cluster-list a {
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: var(--border);
+    text-underline-offset: 0.15em;
+  }
+
+  .cluster-list a:hover {
+    color: var(--coral);
+    text-decoration-color: currentColor;
+  }
+
+  .cluster-list p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/use-cases/legacy-codebase-modernization.astro
+++ b/book-website/src/pages/use-cases/legacy-codebase-modernization.astro
@@ -1,0 +1,84 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Legacy Codebase Modernization"
+  description="Teams inheriting an old system usually reach for a rewrite. C-DAD offers a way to make the system safely navigable first, one capability at a time, without betting months on a clean slate."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Use Cases</p>
+      <h1>Legacy Codebase Modernization</h1>
+
+      <p>
+        Somebody on the team inherited a system nobody currently working
+        on it originally built. That's the starting condition for most
+        legacy modernization work, and it explains why so much of it goes
+        sideways. The people who understood why the retry logic works the
+        way it does, or why that one service calls an internal API instead
+        of the obvious external one, left the company two reorgs ago.
+        What's left is code that runs correctly and explains nothing.
+      </p>
+      <p>
+        The default response is usually a rewrite, and it's an
+        understandable one. But a rewrite spends months of senior
+        engineering time and produces a system that's cleaner without
+        being any more legible, because the tribal knowledge that made the
+        old system dangerous to touch never made it into the new one
+        either. Nobody wrote it down the first time, and a rewrite project
+        rarely has a mechanism to force that writing-down to happen along
+        the way.
+      </p>
+      <p>
+        C-DAD's answer starts smaller. Run <code>cdad check</code> against
+        the current system to get an honest baseline, then
+        <code>cdad roadmap</code> to see which capabilities are both risky
+        and frequently touched, the ones where an unsafe change would
+        actually hurt. Extract and contract those first with
+        <code>cdad init</code>, validate them with
+        <code>cdad validate --all --strict</code> before anything merges,
+        and use <code>cdad graph</code> to see how the pieces you've
+        extracted connect to the pieces you haven't gotten to yet.
+      </p>
+      <p>
+        This doesn't produce a modernized system on day one, and it isn't
+        trying to. It produces a system that gets safer to extend one
+        capability at a time, with the riskiest parts addressed first
+        instead of last, which is usually the opposite order a big rewrite
+        ends up tackling them in once the schedule gets tight.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/use-cases/")}>&larr; Use Cases</a>
+        <a href={withBase("/use-cases/onboarding-new-engineers/")}>Onboarding New Engineers &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/use-cases/microservices-with-many-owners.astro
+++ b/book-website/src/pages/use-cases/microservices-with-many-owners.astro
@@ -1,0 +1,83 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Microservices with Many Owners"
+  description="Once a microservices system outgrows any single team's full understanding, the capability graph becomes the shared map that lets people and agents see how the pieces actually connect."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Use Cases</p>
+      <h1>Microservices with Many Owners</h1>
+
+      <p>
+        Microservices architectures solve a real organizational problem:
+        they let teams ship independently without stepping on each
+        other's deploys. They also tend to solve that problem by creating
+        a new one, which is that after a few years and a few reorgs, no
+        single person, and often no single team, understands how the
+        whole system fits together anymore. Ownership moves, services get
+        inherited, and the dependency map that used to live in one
+        architect's head never made it anywhere durable.
+      </p>
+      <p>
+        That gap shows up constantly in incident reviews. A team changes a
+        field in a service they own, tests it thoroughly against their own
+        contract with the world, and ships it, only to discover an hour
+        later that three other services downstream were relying on
+        behavior nobody documented as a dependency. The service boundary
+        was clear. The knowledge boundary wasn't.
+      </p>
+      <p>
+        The capability graph is built for exactly this. <code>cdad graph</code>
+        renders the dependency map of every contracted capability in the
+        repo, as Mermaid diagrams for humans to read visually and as a
+        JSON adjacency list stable enough for other tooling to depend on.
+        It can be scoped to one capability, one domain, or filtered by
+        lifecycle state, so a team about to change something can actually
+        see what connects to it before they ship, instead of finding out
+        from an incident.
+      </p>
+      <p>
+        This doesn't require every team to agree on shared ownership of
+        the whole system, which was never realistic past a certain scale
+        anyway. It requires each team to contract the capabilities they
+        own well enough that the graph reflects reality, so that the next
+        team touching an adjacent service can see the connection instead
+        of learning about it the hard way.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/use-cases/preparing-for-ai-coding-agents/")}>&larr; Preparing for AI Coding Agents</a>
+        <a href={withBase("/use-cases/regulated-industries-and-compliance/")}>Regulated Industries and Compliance &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/use-cases/onboarding-new-engineers.astro
+++ b/book-website/src/pages/use-cases/onboarding-new-engineers.astro
@@ -1,0 +1,86 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Onboarding New Engineers"
+  description="A new hire's first months usually go to reconstructing tribal knowledge one Slack question at a time. A contract turns that reconstruction into something they can just read."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Use Cases</p>
+      <h1>Onboarding New Engineers</h1>
+
+      <p>
+        Ask any engineer what their first three months at a new job
+        actually involved and the honest answer is rarely "reading
+        documentation." It's asking a teammate why a service behaves a
+        certain way, getting a half-remembered answer, and slowly building
+        a mental map of the parts of the system that don't work the way
+        the code alone suggests they should. That process has a name in
+        most engineering orgs: ramp-up time. It's expensive, it's slow,
+        and it depends entirely on which teammates happen to be around and
+        willing to answer questions that day.
+      </p>
+      <p>
+        The knowledge a new engineer is reconstructing during that period
+        is exactly the tribal knowledge a contract is built to capture,
+        not what the code does, which they can read for themselves, but
+        why it does it, what would break if they changed it, and what got
+        tried before and didn't work. None of that is visible from the
+        implementation alone, and none of it shows up reliably in a wiki
+        that hasn't been updated since the person who wrote it moved
+        teams.
+      </p>
+      <p>
+        A capability with a contract gives a new engineer something closer
+        to a conversation with whoever built it, minus the wait for that
+        person to have time. They can read the non-goals and immediately
+        know what not to touch. They can read the history and understand
+        why the retry policy looks unusual instead of assuming it's a bug
+        worth fixing. <code>cdad graph</code> shows them how the
+        capability connects to the rest of the system, so their first
+        change doesn't quietly break something three services away that
+        nobody mentioned in their onboarding doc.
+      </p>
+      <p>
+        This doesn't eliminate the need for a real onboarding process,
+        pairing sessions, or a manager checking in during week two. What
+        it does is take the highest-risk, least-documented parts of the
+        system, the ones a new hire is most likely to break by accident,
+        and make them legible before the new hire ever has to guess.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/use-cases/legacy-codebase-modernization/")}>&larr; Legacy Codebase Modernization</a>
+        <a href={withBase("/use-cases/preparing-for-ai-coding-agents/")}>Preparing for AI Coding Agents &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/use-cases/preparing-for-ai-coding-agents.astro
+++ b/book-website/src/pages/use-cases/preparing-for-ai-coding-agents.astro
@@ -1,0 +1,88 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Preparing for AI Coding Agents"
+  description="Pointing an agent at a codebase before the codebase can explain itself is how agents make confident, wrong changes. Legibility has to come first."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Use Cases</p>
+      <h1>Preparing for AI Coding Agents</h1>
+
+      <p>
+        This is the use case the rest of the site keeps circling back to,
+        because it's the one that made the other four visible in the
+        first place. An organization decides to let an AI agent make
+        changes in production code, points it at the repository, and
+        discovers within a week that the agent is fast, confident, and
+        occasionally catastrophically wrong in ways a human engineer with
+        the same tenure never would have been.
+      </p>
+      <p>
+        The agent isn't making a technical mistake. It's making a
+        knowledge mistake. It sees code that looks like it does one thing,
+        reasons from that surface, and has no way to know that a business
+        rule buried three functions deep exists because of a regulatory
+        requirement, or that the obvious refactor it's about to propose
+        was already tried and reverted for reasons nobody wrote down where
+        the agent could find them. A human engineer with tenure would have
+        absorbed that context by osmosis. An agent starts every session
+        with none of it.
+      </p>
+      <p>
+        Legibility, in the sense this toolkit uses the word, is the degree
+        to which a capable engineer or agent can understand why a
+        capability behaves the way it does without relying on tribal
+        knowledge. That's the property that has to exist before an agent
+        touches production code safely, and it's a property of the
+        system, not of the agent. No amount of prompting fixes a codebase
+        that has never declared its own reasoning anywhere an agent can
+        read it.
+      </p>
+      <p>
+        The path here is the same <code>check</code>, <code>roadmap</code>,
+        <code>init</code>, <code>validate</code>, <code>graph</code> cycle
+        used everywhere else in the toolkit, run specifically against the
+        capabilities you're about to let an agent operate on first. Score
+        them, extract the riskiest ones, contract what the agent needs to
+        know, and validate that the contract stays true before you widen
+        the agent's scope. It's a smaller, less exciting step than "turn
+        the agent loose and see what happens," and it's the one that
+        actually holds up once the agent starts making real changes.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/use-cases/onboarding-new-engineers/")}>&larr; Onboarding New Engineers</a>
+        <a href={withBase("/use-cases/microservices-with-many-owners/")}>Microservices with Many Owners &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/use-cases/regulated-industries-and-compliance.astro
+++ b/book-website/src/pages/use-cases/regulated-industries-and-compliance.astro
@@ -1,0 +1,89 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Regulated Industries and Compliance"
+  description="Regulated systems accumulate exception paths nobody wrote down anywhere durable. A contract is where those exceptions get declared instead of rediscovered during an audit."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Use Cases</p>
+      <h1>Regulated Industries and Compliance</h1>
+
+      <p>
+        Every regulated system has a version of the same capability: the
+        one with the strange conditional buried in it that exists because
+        of a rule from a regulator, a specific customer contract, or an
+        incident that happened long enough ago that only one or two people
+        remember why. Nobody added that conditional for fun. Removing it,
+        or letting an agent "clean it up" because it looks like dead code,
+        is exactly the kind of change that turns into a compliance
+        incident.
+      </p>
+      <p>
+        The legibility audit framework this toolkit is built around asks
+        four diagnostic questions about any capability, and one of them is
+        specifically about this problem: can you find every exception
+        path driven by a customer, a regulation, or something that
+        happened years ago. Most teams working in a regulated space, when
+        they ask this question honestly, find the answer is no. The
+        exceptions exist in the code. The reasons for them exist in a
+        handful of people's memory, or in a compliance document nobody
+        engineering-facing ever reads.
+      </p>
+      <p>
+        A contract gives that reasoning a durable, structured home. The
+        non-goals section says what the capability deliberately doesn't
+        do, which matters as much for an auditor as it does for an
+        engineer, since a lot of compliance review is really just
+        verifying scope. The history section captures the lesson an
+        incident created, not just the fact that the incident happened, so
+        the constraint survives past the memory of whoever was on call
+        that day. And because <code>cdad validate</code> checks the
+        contract against the running capability, the declared exception
+        paths can't quietly drift out of sync with what the system
+        actually does.
+      </p>
+      <p>
+        None of this replaces a real compliance function or the legal
+        review a regulated change actually needs. What it does is make
+        sure the engineering side of that picture, the exception paths
+        embedded in code, is legible enough that neither a new engineer
+        nor an agent proposes removing something a regulator required,
+        simply because nothing told them it mattered.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/use-cases/microservices-with-many-owners/")}>&larr; Microservices with Many Owners</a>
+        <a href={withBase("/use-cases/")}>Use Cases &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/why-c-dad/from-documentation-to-contracts.astro
+++ b/book-website/src/pages/why-c-dad/from-documentation-to-contracts.astro
@@ -1,0 +1,85 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="From Documentation to Contracts"
+  description="A wiki describes a system in prose a person has to translate. A contract declares it in a structured form an agent can act on directly. That distinction is the whole argument for C-DAD."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Why C-DAD</p>
+      <h1>From documentation to contracts</h1>
+
+      <p>
+        The instinctive fix for tribal knowledge is to write more of it
+        down. A better wiki. Clearer onboarding docs. A documentation
+        sprint every quarter to catch up on what's drifted. All of this is
+        a genuine, well-intentioned response, and none of it solves the
+        actual problem, because it treats a structural gap as a writing
+        gap.
+      </p>
+      <p>
+        Documentation has a ceiling that has nothing to do with how well
+        it's written. It's prose, meant for a person to read and
+        interpret, and interpretation is exactly the step an AI agent
+        can't reliably do. A wiki page can say "retries are capped to
+        avoid overloading the payment processor during an outage" and a
+        human reads that and understands the intent behind it. An agent
+        reads the same sentence and has to guess how that intent
+        translates into a specific number, a specific exception case, a
+        specific piece of code it's allowed to touch. Guessing is where
+        things go wrong.
+      </p>
+      <p>
+        A contract closes that gap by being structured instead of
+        narrative. It doesn't just describe a capability, it declares
+        what the capability does, why it does it that way, what it
+        depends on, and what would break if you changed it, in a format
+        specific enough for a human to trust and consistent enough for a
+        machine to parse without translation. The difference isn't
+        polish. It's that a contract is built to be acted on, not just
+        read.
+      </p>
+      <p>
+        This is why C-DAD treats contracts as a structural fix rather than
+        better documentation with a new name. Once a capability has a
+        contract, the tribal knowledge that used to live in one person's
+        head is available to the next engineer, the next hire, and the
+        next agent, on equal footing, and it stays available after that
+        person leaves the team.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/why-c-dad/the-cost-of-tribal-knowledge/")}>&larr; The cost of tribal knowledge</a>
+        <a href={withBase("/core-model/")}>The core model &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/why-c-dad/index.astro
+++ b/book-website/src/pages/why-c-dad/index.astro
@@ -1,0 +1,79 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Why C-DAD"
+  description="Contract-Driven AI Development exists because AI agents can read your entire codebase and still get your system wrong. Here's the case for why contracts, not more documentation, actually fix that."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Contract-Driven AI Development</p>
+      <h1>Why C-DAD</h1>
+
+      <p>
+        An AI agent can read every file in your repository in a few
+        seconds. It still can't ask a senior engineer what a payment
+        constraint actually means, or why a service calls another one out
+        of the order that looks obvious from the outside. That gap is
+        where most agent-generated changes quietly go wrong, and it isn't
+        something a bigger context window fixes.
+      </p>
+      <p>
+        Contract-Driven AI Development is the operating model built for
+        that gap specifically. Not a coding standard, not a linting rule,
+        a way of making a system declare what it knows about itself, in a
+        form both people and agents can act on. The pages below make the
+        case for it from four different angles: the actual problem it
+        solves, why legibility matters more than raw model capability, what
+        tribal knowledge really costs a team, and why documentation was
+        never going to be the fix.
+      </p>
+
+      <ul class="cluster-list">
+        <li><a href={withBase("/why-c-dad/what-problem-does-c-dad-solve/")}>What problem does C-DAD solve?</a></li>
+        <li><a href={withBase("/why-c-dad/why-ai-agents-need-legible-systems/")}>Why AI agents need legible systems</a></li>
+        <li><a href={withBase("/why-c-dad/the-cost-of-tribal-knowledge/")}>The cost of tribal knowledge</a></li>
+        <li><a href={withBase("/why-c-dad/from-documentation-to-contracts/")}>From documentation to contracts</a></li>
+      </ul>
+
+      <p class="see-also">
+        See also: <a href={withBase("/core-model/")}>the core model</a> for what a contract and a capability graph actually are, or <a href={withBase("/tribal-knowledge/")}>Chapter 2 of the book</a> for where this argument started.
+      </p>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .cluster-list {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 0.6rem;
+    margin: 2rem 0;
+  }
+
+  .cluster-list a {
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: var(--border);
+    text-underline-offset: 0.15em;
+  }
+
+  .cluster-list a:hover {
+    color: var(--coral);
+    text-decoration-color: currentColor;
+  }
+
+  .see-also {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    margin-top: 2rem;
+  }
+
+  .see-also a {
+    color: var(--text);
+    text-decoration: underline;
+  }
+</style>

--- a/book-website/src/pages/why-c-dad/the-cost-of-tribal-knowledge.astro
+++ b/book-website/src/pages/why-c-dad/the-cost-of-tribal-knowledge.astro
@@ -1,0 +1,83 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="The Cost of Tribal Knowledge"
+  description="Tribal knowledge isn't a documentation gap, it's a standing cost that shows up in onboarding time, departure risk, and every AI-generated change that looks right and isn't."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Why C-DAD</p>
+      <h1>The cost of tribal knowledge</h1>
+
+      <p>
+        Tribal knowledge is easy to underprice because it doesn't show up
+        as a line item anywhere. Nobody budgets for it. It just quietly
+        taxes everything a team does, in ways that are individually small
+        enough to shrug off and collectively enormous.
+      </p>
+      <p>
+        The most visible cost is onboarding. A new hire doesn't actually
+        spend their first weeks learning to code, they spend it
+        reconstructing context that already existed somewhere, just not
+        anywhere they could find it. The constraint behind a strange-
+        looking function. The reason a retry sits at three attempts
+        instead of five. That reconstruction happens one Slack message and
+        one hallway conversation at a time, and it happens again for every
+        new hire, because none of it gets captured the first time either.
+      </p>
+      <p>
+        The second cost is departure risk, and it's the more dangerous
+        one. When a senior engineer who's been there five years leaves,
+        the org chart doesn't show what actually walked out the door. It's
+        every constraint they were carrying that never made it into a
+        document, a comment, or a ticket. The next person to touch that
+        code isn't just less experienced. They're missing information that
+        doesn't exist anywhere else, and there's no efficient way to get it
+        back.
+      </p>
+      <p>
+        The third cost is the newest one, and it's what makes the first
+        two urgent instead of merely annoying. AI coding agents are now
+        the primary interface a lot of engineers use to touch a codebase,
+        and agents inherit the tribal knowledge gap completely. They read
+        every file in seconds and still can't ask what a constraint means,
+        so every undocumented decision becomes a landmine an agent will
+        eventually step on, with a commit message that looks entirely
+        reasonable right up until it isn't.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/why-c-dad/why-ai-agents-need-legible-systems/")}>&larr; Why AI agents need legible systems</a>
+        <a href={withBase("/why-c-dad/from-documentation-to-contracts/")}>From documentation to contracts &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/why-c-dad/what-problem-does-c-dad-solve.astro
+++ b/book-website/src/pages/why-c-dad/what-problem-does-c-dad-solve.astro
@@ -1,0 +1,79 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="What Problem Does C-DAD Solve?"
+  description="AI coding agents are fast and confident and frequently wrong in ways that pass code review. C-DAD exists to close the specific gap that causes it."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Why C-DAD</p>
+      <h1>What problem does C-DAD solve?</h1>
+
+      <p>
+        Every team that's put a coding agent on a real codebase has hit the
+        same wall. The agent writes something that compiles, passes the
+        obvious tests, and looks exactly like what a competent engineer
+        would have written. Then it breaks something in production that
+        nobody thought to check, because the constraint that would have
+        stopped it was never written down anywhere the agent could see.
+      </p>
+      <p>
+        That's not a model problem. Bigger context windows and smarter
+        reasoning don't fix it, because the missing information was never
+        in the codebase to begin with. It lived in a senior engineer's
+        head, in a Slack thread from eighteen months ago, in the memory of
+        why a retry policy has an odd exception baked into it. Reading
+        every file in the repository doesn't recover that. You can't grep
+        for a decision nobody recorded.
+      </p>
+      <p>
+        Contract-Driven AI Development treats this as a structural gap,
+        not a tooling gap. The fix isn't a smarter agent or a longer
+        prompt. It's making the system say, in a form both a person and a
+        model can act on, what a capability does, why it does it that way,
+        and what would break if you changed it. Once that exists, an agent
+        stops guessing at intent and starts reading it directly.
+      </p>
+      <p>
+        C-DAD is the discipline built around producing that artifact:
+        what a contract has to contain, how to decide which parts of a
+        system need one first, and how contracts compose into something
+        larger than any single file, a map of how a whole system actually
+        works.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/why-c-dad/")}>&larr; Why C-DAD</a>
+        <a href={withBase("/why-c-dad/why-ai-agents-need-legible-systems/")}>Why AI agents need legible systems &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/why-c-dad/why-ai-agents-need-legible-systems.astro
+++ b/book-website/src/pages/why-c-dad/why-ai-agents-need-legible-systems.astro
@@ -1,0 +1,81 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<BaseLayout
+  title="Why AI Agents Need Legible Systems"
+  description="Legibility is a property of the system, not the model. Here's why the smartest agent in the world still fails against a codebase that doesn't explain itself."
+>
+  <section class="section">
+    <div class="wrap">
+      <p class="eyebrow">Why C-DAD</p>
+      <h1>Why AI agents need legible systems</h1>
+
+      <p>
+        Legibility is a specific claim, and it's worth being precise about
+        it: could a capable engineer who has never touched your team or
+        your codebase make a safe change to one piece of it, using only
+        what the system itself makes available? Not what's in someone's
+        head. Not what a senior engineer could explain in a five minute
+        conversation. Just what's actually there to read.
+      </p>
+      <p>
+        Most production systems fail that test constantly, and for years
+        that was fine, because the people making changes usually had the
+        missing context anyway. They'd worked there long enough, or they
+        knew who to ask. An AI agent doesn't have that option. It can't
+        tap someone on the shoulder. It can't sit in on the onboarding
+        conversation where a new hire learns which shortcuts are actually
+        landmines. It only has what's written down, and if the system
+        isn't legible, what's written down isn't enough.
+      </p>
+      <p>
+        This is why the size and capability of the underlying model
+        matters less than people expect. A more capable model is still
+        bounded by what the system tells it. Point the best coding agent
+        available at an illegible system and it will produce the same
+        class of confident, plausible, wrong changes that a less capable
+        model would, because the failure isn't in the reasoning. It's in
+        the input.
+      </p>
+      <p>
+        Legibility, in other words, is a property you build into the
+        system, not a capability you wait for a vendor to ship. A
+        capability graph and a set of contracts make a system legible on
+        purpose, which is the only way legibility reliably shows up at
+        all.
+      </p>
+
+      <BuyLinks />
+
+      <nav class="chapter-nav" aria-label="Related pages">
+        <a href={withBase("/why-c-dad/what-problem-does-c-dad-solve/")}>&larr; What problem does C-DAD solve?</a>
+        <a href={withBase("/why-c-dad/the-cost-of-tribal-knowledge/")}>The cost of tribal knowledge &rarr;</a>
+      </nav>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/styles/global.css
+++ b/book-website/src/styles/global.css
@@ -117,9 +117,9 @@ a {
 }
 
 /* Homepage sunrise: while the hero plays its night-to-day sequence, the
-   page around it lightens in sync — deep night blue (sampled from the
-   night frame's sky) warming up to the theme background. Classes are set
-   by the homepage's sunrise scripts; timing vars are copied from the
+   page around it lightens in sync. Deep night blue (sampled from the
+   night frame's sky) warms up to the theme background. Classes are set
+   by the homepage's sunrise scripts, and timing vars are copied from the
    hero so the two animations can never drift apart. */
 html.sunrise-pending body {
   background: #0c1017;


### PR DESCRIPTION
## Summary
- Writes real, humanized prose for every remaining book chapter, the appendix, and 9 new SEO content clusters (Why C-DAD, Core Model, How C-DAD Works, Glossary, Comparisons, Use Cases, Proof, Examples, Toolkit) plus a site FAQ, 80 files / ~6,800 lines of new content
- All new content is grounded in the real toolkit docs (`docs/concepts.md`, `docs/anti-patterns.md`, `docs/cli-reference.md`, `docs/adoption-journey.md`) and the book manuscript themes already used elsewhere on the site
- Fixes every em dash and prose semicolon site-wide (including pre-existing pages, the default meta description, and the `<title>` separator in `BaseLayout.astro`) to comply with a strict no-em-dash, no-semicolon writing constraint
- Expands the footer into a 4-column sitemap so all 9 new clusters have a real inbound link from every page, nothing is orphaned from navigation

## Test plan
- [x] `astro build` completes cleanly, 78 pages generated with no errors
- [x] Site-wide grep confirms zero `—` / `&mdash;` characters and zero prose semicolons outside code/CSS
- [x] Verified all footer sitemap links resolve to real base-path-aware URLs (no 404s) via generated `dist/` output
- [x] Spot-checked several new pages (Core Model, Glossary, FAQ) live in the browser preview, correct titles, no console errors
- [ ] Manual review of prose quality/tone across all 52 new pages (large volume, worth a skim before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)