### PR TITLE
Point the site at thedayafteraibook.com

### DIFF
--- a/book-website/README.md
+++ b/book-website/README.md
@@ -46,7 +46,7 @@ real manuscript, kept to non-spoiler summaries.
 
 ## Deployment
 
-Live at **https://enricopiovesan.github.io/the-day-after-toolkit/**.
+Live at **https://thedayafteraibook.com**.
 
 A GitHub Actions workflow at `.github/workflows/book-website-deploy.yml`
 builds this site and deploys it to GitHub Pages on every push to `main`

--- a/book-website/astro.config.mjs
+++ b/book-website/astro.config.mjs
@@ -1,13 +1,10 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 
-// Deployed as a GitHub Pages *project* site (this repo isn't named
-// <user>.github.io), so it's served from /the-day-after-toolkit/, not
-// from "/". All internal links/assets go through src/utils/url.ts's
-// withBase() to stay correct here. If a custom domain is added later,
-// drop `base` and withBase() becomes a no-op automatically.
+// Served from the custom domain at the site root, so no `base` path.
+// All internal links/assets still go through src/utils/url.ts's
+// withBase(), which is a no-op once `base` is unset.
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://enricopiovesan.github.io',
-  base: '/the-day-after-toolkit/',
+  site: 'https://thedayafteraibook.com',
 });

--- a/book-website/public/CNAME
+++ b/book-website/public/CNAME
@@ -1,0 +1,1 @@
+thedayafteraibook.com


### PR DESCRIPTION
## Summary
- DNS is already live at the registrar: 4 A records for `@` to GitHub Pages' IPs, and `www` CNAME to `enricopiovesan.github.io`
- Drops the `/the-day-after-toolkit/` base path in `astro.config.mjs` now that the site serves from the domain root, `site` now points at `https://thedayafteraibook.com`
- Adds `public/CNAME` so GitHub Pages registers the custom domain on deploy

## Test plan
- [x] `astro build` completes cleanly, 78 pages generated
- [x] Verified no internal links carry the old `/the-day-after-toolkit/` prefix anywhere in the build output
- [x] Confirmed `dist/CNAME` contains `thedayafteraibook.com`
- [ ] After merge, confirm GitHub registers the domain and issues HTTPS (may take a few minutes once DNS is fully propagated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)