### PR TITLE
Simplify header to match Figma: flat, fixed, no notches or corners

### DIFF
--- a/book-website/src/components/Header.astro
+++ b/book-website/src/components/Header.astro
@@ -19,31 +19,22 @@ const currentPath = Astro.url.pathname;
 ---
 
 <header class="site-header" class:list={[{ "site-header--overlay": overlay }]}>
-  <div class:list={["site-header__inner", { "wrap wrap--wide": !overlay }]}>
-    <div class="site-header__group">
-      <a href={withBase("/")} class="logo-tab">
-        <img src={withBase("/logo.svg")} alt="The Day After AI" class="logo-tab__image" />
-      </a>
+  <div class="site-header__inner wrap wrap--wide">
+    <a href={withBase("/")} class="site-header__logo">
+      <img src={withBase("/logo.svg")} alt="The Day After AI" class="site-header__logo-image" />
+    </a>
 
-      <nav class="site-nav" aria-label="Primary">
-        <ul>
-          {
-            navItems.map((item) => (
-              <li>
-                <a
-                  href={item.href}
-                  aria-current={currentPath === item.href ? "page" : undefined}
-                >
-                  {item.label}
-                </a>
-              </li>
-            ))
-          }
-        </ul>
-      </nav>
-    </div>
+    <nav class="site-nav" aria-label="Primary">
+      {
+        navItems.map((item) => (
+          <a href={item.href} aria-current={currentPath === item.href ? "page" : undefined}>
+            {item.label}
+          </a>
+        ))
+      }
+    </nav>
 
-    <div class="action-tab">
+    <div class="site-header__actions">
       <button
         type="button"
         class="theme-toggle"
@@ -55,10 +46,10 @@ const currentPath = Astro.url.pathname;
           <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
         </svg>
       </button>
-      <a class="action-tab__link" href="https://github.com/enricopiovesan/the-day-after-toolkit">GitHub</a>
-      <a class="action-tab__link" href="https://medium.com/software-architecture-in-the-age-of-ai">Blog</a>
+      <a class="site-header__link" href="https://github.com/enricopiovesan/the-day-after-toolkit">GitHub</a>
+      <a class="site-header__link" href="https://medium.com/software-architecture-in-the-age-of-ai">Blog</a>
       <!-- TODO: replace with the real retailer URL once the book is listed -->
-      <a class="btn btn--sage action-tab__cta" href="#">Pre-order on Amazon</a>
+      <a class="btn btn--sage site-header__cta" href="#">Pre-order on Amazon</a>
     </div>
   </div>
 </header>
@@ -78,132 +69,77 @@ const currentPath = Astro.url.pathname;
 
 <style>
   .site-header {
-    padding: 1.5rem 0;
-  }
-
-  .site-header--overlay {
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     right: 0;
-    z-index: 10;
-    padding: 0;
+    z-index: 50;
+    height: var(--header-height);
+    display: flex;
+    align-items: center;
+    background: color-mix(in srgb, var(--bg) 88%, transparent);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .site-header--overlay {
+    background: linear-gradient(to bottom, rgba(10, 10, 10, 0.55), rgba(10, 10, 10, 0.2) 70%, transparent);
+    border-bottom: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
   }
 
   .site-header__inner {
     display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
+    align-items: center;
+    gap: 2rem;
+    width: 100%;
   }
 
-  .site-header__group {
+  .site-header__logo {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    flex-shrink: 0;
   }
 
-  .logo-tab,
-  .action-tab {
-    position: relative;
-    background: #1e1e1e;
-    color: #f5f3ee;
-    height: 94px;
-    display: flex;
-    align-items: center;
-    padding: 0 2rem;
-  }
-
-  /* The tabs themselves are plain rectangles. At the top, where each tab
-     meets the open gap toward the nav pill, a separate small patch sits
-     just outside it and curves away to transparent, revealing the photo
-     through a concave notch. At the bottom, it's the other way around:
-     the inner corner (facing the gap) is a plain rounded corner on the
-     tab itself, and the outer corner (true page edge) gets the notch
-     patch, positioned below the tab instead of beside it. */
-  .logo-tab {
-    border-radius: 0 0 2rem 0;
-  }
-
-  .action-tab {
-    border-radius: 0 0 0 2rem;
-  }
-
-  .logo-tab::before,
-  .logo-tab::after,
-  .action-tab::before,
-  .action-tab::after {
-    content: "";
-    position: absolute;
-    width: 2rem;
-    height: 2rem;
-  }
-
-  .logo-tab::after {
-    top: 0;
-    left: 100%;
-    background: radial-gradient(circle at bottom right, transparent 2rem, #1e1e1e 2rem);
-  }
-
-  .logo-tab::before {
-    top: 100%;
-    left: 0;
-    background: radial-gradient(circle at bottom right, transparent 2rem, #1e1e1e 2rem);
-  }
-
-  .action-tab::after {
-    top: 0;
-    right: 100%;
-    background: radial-gradient(circle at bottom left, transparent 2rem, #1e1e1e 2rem);
-  }
-
-  .action-tab::before {
-    top: 100%;
-    right: 0;
-    background: radial-gradient(circle at bottom left, transparent 2rem, #1e1e1e 2rem);
-  }
-
-  .logo-tab__image {
+  .site-header__logo-image {
     display: block;
     width: 126px;
     height: 31px;
   }
 
   .site-nav {
-    margin-top: 0.4rem;
-  }
-
-  .site-nav ul {
-    list-style: none;
     display: flex;
-    gap: 0.25rem;
-    margin: 0;
-    padding: 0.3rem;
-    background: #c9c6c5;
-    border-radius: 999px;
+    align-items: center;
+    gap: 1.25rem;
     flex-wrap: wrap;
   }
 
   .site-nav a {
-    display: block;
     text-decoration: none;
-    color: #201d18;
+    color: var(--text);
     font-family: var(--font-mono);
     font-size: 0.8rem;
     font-weight: 500;
-    padding: 0.5rem 0.9rem;
-    border-radius: 999px;
     white-space: nowrap;
+  }
+
+  .site-header--overlay .site-nav a {
+    color: rgba(245, 243, 238, 0.9);
   }
 
   .site-nav a:hover,
   .site-nav a[aria-current="page"] {
-    background: #fff;
+    color: var(--coral);
   }
 
-  .action-tab {
+  .site-header__actions {
     display: flex;
     align-items: center;
     gap: 1.1rem;
+    margin-left: auto;
+    flex-shrink: 0;
   }
 
   .theme-toggle {
@@ -215,40 +151,44 @@ const currentPath = Astro.url.pathname;
     border-radius: 999px;
     border: none;
     background: transparent;
-    color: #f5f3ee;
+    color: var(--text);
     cursor: pointer;
     padding: 0;
+  }
+
+  .site-header--overlay .theme-toggle {
+    color: rgba(245, 243, 238, 0.9);
   }
 
   .theme-toggle:hover {
     color: var(--coral);
   }
 
-  .action-tab__link {
+  .site-header__link {
     text-decoration: none;
-    color: #f5f3ee;
+    color: var(--text);
     font-size: 0.9rem;
     white-space: nowrap;
   }
 
-  .action-tab__link:hover {
+  .site-header--overlay .site-header__link {
+    color: rgba(245, 243, 238, 0.9);
+  }
+
+  .site-header__link:hover {
     color: var(--coral);
   }
 
-  .action-tab__cta {
+  .site-header__cta {
     padding: 0.55rem 1.1rem;
     font-size: 0.85rem;
     white-space: nowrap;
   }
 
-  @media (max-width: 860px) {
-    .site-header__inner {
-      flex-wrap: wrap;
-      row-gap: 0.75rem;
-    }
-
-    .site-header__group {
-      flex-wrap: wrap;
+  @media (max-width: 900px) {
+    .site-nav,
+    .site-header__link {
+      display: none;
     }
   }
 </style>

--- a/book-website/src/layouts/SubpageLayout.astro
+++ b/book-website/src/layouts/SubpageLayout.astro
@@ -99,7 +99,7 @@ const hasToc = toc.length > 0;
   .section-nav {
     display: none;
     position: sticky;
-    top: 6.5rem;
+    top: calc(var(--header-height) + 1.5rem);
     align-self: start;
     max-height: calc(100vh - 8rem);
     overflow-y: auto;
@@ -222,7 +222,7 @@ const hasToc = toc.length > 0;
   .toc-rail {
     display: none;
     position: sticky;
-    top: 6.5rem;
+    top: calc(var(--header-height) + 1.5rem);
     align-self: start;
     max-height: calc(100vh - 8rem);
     overflow-y: auto;

--- a/book-website/src/pages/index.astro
+++ b/book-website/src/pages/index.astro
@@ -100,19 +100,6 @@ const heroTiming = `
     }
   </script>
   <div class="hero-wrap" id="hero-wrap" style={heroTiming}>
-    <div class="hero__ambient" aria-hidden="true">
-      {
-        heroStages.map((src, i) => (
-          <img
-            class="hero__ambient-image"
-            style={`--stage: ${i}; z-index: ${heroStages.length - i};`}
-            src={src}
-            alt=""
-            loading="eager"
-          />
-        ))
-      }
-    </div>
     <section class="hero" id="hero">
       <Header overlay />
       <div class="hero__zoom" aria-hidden="true">
@@ -250,65 +237,15 @@ const heroTiming = `
 <style>
   .hero-wrap {
     position: relative;
-    max-width: 1500px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
+    margin: calc(-1 * var(--header-height)) 0 0;
   }
 
   .hero {
     position: relative;
     z-index: 1;
-    margin-top: 1.5rem;
     aspect-ratio: 1624 / 896;
     overflow: hidden;
-    border-radius: 2rem;
     height: 100%;
-  }
-
-  /* Ambient light spilling out around the hero: the same photos, heavily
-     blurred and enlarged so the blur's own soft edge never shows, sitting
-     behind the hero and bleeding a little past its edges. It cross-fades
-     night-to-day on the same schedule as the sharp images (same keyframe,
-     same delays), just softened and kept faint. Real photo color (night
-     blue warming to sunrise gold), not a synthetic tint. */
-  .hero__ambient {
-    position: absolute;
-    inset: -2rem;
-    z-index: 0;
-    overflow: hidden;
-    border-radius: 2.5rem;
-    opacity: 0.4;
-    pointer-events: none;
-  }
-
-  .hero__ambient-image {
-    position: absolute;
-    inset: -15%;
-    width: 130%;
-    height: 130%;
-    object-fit: cover;
-    filter: blur(3rem);
-    opacity: 0;
-  }
-
-  .hero__ambient-image:last-child {
-    opacity: 1;
-  }
-
-  :global(.sunrise-pending) .hero__ambient-image:first-child {
-    opacity: 1;
-  }
-
-  .hero--animate .hero__ambient-image {
-    opacity: 1;
-    animation: hero-stage-out var(--hero-fade) ease-in-out forwards;
-    animation-delay: calc(
-      var(--hero-first-hold) + var(--stage) * var(--hero-stage-gap)
-    );
-  }
-
-  .hero--animate .hero__ambient-image:last-child {
-    animation: none;
   }
 
   .hero__zoom {

--- a/book-website/src/styles/global.css
+++ b/book-website/src/styles/global.css
@@ -18,6 +18,7 @@
   --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", "Roboto Mono", monospace;
   --content-width: 46rem;
+  --header-height: 4rem;
 }
 
 :root[data-theme="dark"] {
@@ -55,6 +56,7 @@ body {
   font-family: var(--font-body);
   line-height: 1.6;
   transition: background-color 0.2s ease, color 0.2s ease;
+  padding-top: var(--header-height);
 }
 
 h1, h2, h3 {
@@ -128,7 +130,7 @@ a {
 .subpage-body h2 {
   font-size: 1.5rem;
   margin: 2.5rem 0 1rem;
-  scroll-margin-top: 6.5rem;
+  scroll-margin-top: calc(var(--header-height) + 1.5rem);
 }
 
 .subpage-body p {
@@ -142,29 +144,6 @@ a {
   color: var(--text-muted);
 }
 
-/* Homepage sunrise: while the hero plays its night-to-day sequence, the
-   page around it lightens in sync. Deep night blue (sampled from the
-   night frame's sky) warms up to the theme background. Classes are set
-   by the homepage's sunrise scripts, and timing vars are copied from the
-   hero so the two animations can never drift apart. */
-html.sunrise-pending body {
-  background: #0c1017;
-}
-
-html.sunrise-play body {
-  animation: sunrise-bg
-    calc(var(--hero-zoom, 5.7s) - var(--hero-first-hold, 1.2s)) ease-in-out
-    var(--hero-first-hold, 1.2s) both;
-}
-
-@keyframes sunrise-bg {
-  from {
-    background-color: #0c1017;
-  }
-  to {
-    background-color: var(--bg);
-  }
-}
 
 .divider {
   height: 1px;


### PR DESCRIPTION
## Summary
- Rebuilds `Header.astro` to match the updated Figma design (`n1XQ7rXluWEvsJ2Zwu61OO`): drops the two dark notched pill tabs and the gray nav pill for one flat translucent bar with plain-text nav links
- Header is now `position: fixed`, persistent across scroll on every page (previously it only overlaid the homepage hero via `position: absolute`, everywhere else it scrolled away normally)
- Transparent gradient scrim variant over the homepage hero, solid blurred bar with a bottom border everywhere else
- Drops the hero's rounded-card treatment (border-radius, side margins) for a flush, edge-to-edge rectangle, per direct confirmation
- Removes the ambient blurred-glow layer and the page-background color sync that went with it, per direct instruction, the night-to-day crossfade and zoom animation on the sharp hero images is unchanged
- Introduces `--header-height` as a shared CSS var so `SubpageLayout`'s sticky rail offsets and scroll-margin-top stay correct instead of a hardcoded value tuned for the old, taller header

## Test plan
- [x] `astro build` completes cleanly, 78 pages generated
- [x] Verified in browser: header is fixed and stays pinned on scroll, on both the homepage (transparent) and an inner page (solid/blurred)
- [x] Confirmed hero is flush at true `top: 0` with `border-radius: 0`, no ambient layer in the DOM
- [x] Confirmed the sunrise crossfade animation still plays correctly after clearing sessionStorage (`hero-zoom` animation active, night frame fading out)
- [x] Mobile: header stays a fixed 64px, nav/text links collapse, logo and CTA remain visible
- [x] No console errors, no em dashes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)