### PR TITLE
Fix panel/heading fidelity, scroll header state, 70vh hero

### DIFF
--- a/book-website/src/components/Header.astro
+++ b/book-website/src/components/Header.astro
@@ -65,6 +65,13 @@ const currentPath = Astro.url.pathname;
     root.setAttribute("data-theme", next);
     localStorage.setItem("theme", next);
   });
+
+  const header = document.querySelector(".site-header");
+  function updateHeaderScrolled() {
+    header?.classList.toggle("is-scrolled", window.scrollY > 8);
+  }
+  updateHeaderScrolled();
+  window.addEventListener("scroll", updateHeaderScrolled, { passive: true });
 </script>
 
 <style>
@@ -88,6 +95,19 @@ const currentPath = Astro.url.pathname;
     border-bottom: none;
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
+  }
+
+  .site-header.is-scrolled {
+    background: rgba(0, 0, 0, 0.8);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .site-header.is-scrolled .site-nav a,
+  .site-header.is-scrolled .theme-toggle,
+  .site-header.is-scrolled .site-header__link {
+    color: rgba(245, 243, 238, 0.9);
   }
 
   .site-header__inner {

--- a/book-website/src/components/PanelSection.astro
+++ b/book-website/src/components/PanelSection.astro
@@ -51,19 +51,19 @@ const { eyebrow, color, columns } = Astro.props;
     gap: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    font-size: 0.95rem;
-    font-weight: 600;
+    font-size: 1.3rem;
+    font-weight: 500;
     margin: 0 0 3rem;
   }
 
   .tick {
     display: inline-block;
     width: 7rem;
-    height: 2px;
+    height: 2.5px;
     background: currentColor;
     transform-origin: bottom left;
     transform: rotate(-45deg);
-    margin-bottom: 0.2rem;
+    margin-bottom: 0.3rem;
   }
 
   .panel__columns {
@@ -73,15 +73,16 @@ const { eyebrow, color, columns } = Astro.props;
   }
 
   .panel__column-title {
+    font-size: 1.35rem;
     font-weight: 600;
-    margin: 0 0 0.6rem;
+    margin: 0 0 0.9rem;
   }
 
   .panel__column-body {
     margin: 0;
-    font-size: 0.9rem;
-    opacity: 0.8;
-    line-height: 1.55;
+    font-size: 1.05rem;
+    opacity: 0.85;
+    line-height: 1.6;
   }
 
   @media (max-width: 720px) {

--- a/book-website/src/components/SectionHeading.astro
+++ b/book-website/src/components/SectionHeading.astro
@@ -36,6 +36,9 @@ const { align = "left" } = Astro.props;
 
   .section-heading .divider {
     flex: 1;
+    height: 1.5px;
+    background: currentColor;
+    opacity: 0.4;
   }
 
   @media (max-width: 640px) {

--- a/book-website/src/pages/index.astro
+++ b/book-website/src/pages/index.astro
@@ -243,9 +243,8 @@ const heroTiming = `
   .hero {
     position: relative;
     z-index: 1;
-    aspect-ratio: 1624 / 896;
+    height: 70vh;
     overflow: hidden;
-    height: 100%;
   }
 
   .hero__zoom {
@@ -386,23 +385,18 @@ const heroTiming = `
     z-index: 2;
   }
 
-  @media (max-width: 640px) {
-    .hero {
-      aspect-ratio: 9 / 16;
-    }
-  }
 
   .section__body {
     display: grid;
     gap: 2rem;
     max-width: 40rem;
-    margin: 0 0 4rem auto;
+    margin: 0 0 5.5rem auto;
     color: var(--text-muted);
     font-size: 0.95rem;
   }
 
   .section__body--left {
-    margin: 0 auto 4rem 0;
+    margin: 0 auto 5.5rem 0;
   }
 
   .section__body p {


### PR DESCRIPTION
## Summary
- Second-pass fixes on the Tribal Knowledge section against a marked-up reference screenshot: panel eyebrow (0.95rem to 1.3rem) and column-title (unset/1rem to 1.35rem) font sizes were both still too small, the divider and diagonal tick were too faint/thin, and the gap before the panel card needed to grow further (4rem to 5.5rem)
- Header now switches to a solid `rgba(0,0,0,0.8)` background once scrolled past 8px, on every page, so nav text stays legible regardless of whether it started as the transparent hero overlay or the solid inner-page bar
- Homepage hero is now an explicit `70vh` instead of an aspect-ratio that could read as closer to full viewport height depending on window size

## Test plan
- [x] `astro build` completes cleanly, 78 pages generated
- [x] Verified in browser: eyebrow/column-title font sizes match target values via computed styles, divider/tick thickness and opacity increased
- [x] Confirmed header background switches to 80% black on scroll (verified via manual scroll event dispatch, since programmatic `scrollTo` doesn't fire native scroll events in the test harness, real user scrolling does)
- [x] Confirmed hero height is exactly 70% of viewport height on both desktop (630/900) and mobile (568/812)
- [x] No console errors (aside from known dev-server HMR websocket noise unrelated to app code), no em dashes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)