### PR TITLE
SEO foundation, IA overhaul, and a new For AI Agents content cluster

### DIFF
--- a/book-website/astro.config.mjs
+++ b/book-website/astro.config.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 
 // Served from the custom domain at the site root, so no `base` path.
 // All internal links/assets still go through src/utils/url.ts's
@@ -7,4 +8,5 @@ import { defineConfig } from 'astro/config';
 // https://astro.build/config
 export default defineConfig({
   site: 'https://thedayafteraibook.com',
+  integrations: [sitemap()],
 });

--- a/book-website/package-lock.json
+++ b/book-website/package-lock.json
@@ -8,6 +8,7 @@
       "name": "book-website",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/sitemap": "^3.7.3",
         "astro": "^7.1.3"
       },
       "engines": {
@@ -241,6 +242,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1996,6 +2008,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2044,6 +2074,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3787,6 +3823,25 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
@@ -3817,6 +3872,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -3940,6 +4001,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/book-website/package.json
+++ b/book-website/package.json
@@ -12,6 +12,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.3",
     "astro": "^7.1.3"
   }
 }

--- a/book-website/public/robots.txt
+++ b/book-website/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://thedayafteraibook.com/sitemap-index.xml

--- a/book-website/src/components/Footer.astro
+++ b/book-website/src/components/Footer.astro
@@ -1,46 +1,23 @@
 ---
 import { withBase } from "../utils/url";
+import { PILLARS, SITE_SECTIONS } from "../data/siteSections";
 
 const year = new Date().getFullYear();
 
-const sitemapColumns = [
-  {
-    heading: "The Book",
-    links: [
-      { href: withBase("/about-the-book/"), label: "about the book" },
-      { href: withBase("/excerpt/"), label: "free excerpt" },
-      { href: withBase("/author/"), label: "author" },
-      { href: withBase("/why-c-dad/"), label: "why C-DAD" },
-    ],
-  },
-  {
-    heading: "The Model",
-    links: [
-      { href: withBase("/core-model/"), label: "core model" },
-      { href: withBase("/how-c-dad-works/"), label: "how C-DAD works" },
-      { href: withBase("/glossary/"), label: "glossary" },
-      { href: withBase("/appendix/"), label: "appendix" },
-    ],
-  },
-  {
-    heading: "The Case",
-    links: [
-      { href: withBase("/comparisons/"), label: "comparisons" },
-      { href: withBase("/use-cases/"), label: "use cases" },
-      { href: withBase("/proof/"), label: "proof" },
-      { href: withBase("/examples/"), label: "examples" },
-    ],
-  },
-  {
-    heading: "The Toolkit",
-    links: [
-      { href: withBase("/toolkit/"), label: "toolkit overview" },
-      { href: withBase("/toolkit/installation/"), label: "installation" },
-      { href: withBase("/faq/"), label: "faq" },
-      { href: withBase("/contact/"), label: "contact" },
-    ],
-  },
-];
+// One footer column per top-level pillar, each showing every section that
+// rolls up into it (as its own mini-cluster of links) so the footer always
+// reflects the real site structure instead of a hand-picked sample. Capped
+// at 4 links per section (the section's own root page plus its top 3
+// flagship subpages) to keep columns readable.
+const footerColumns = PILLARS.map((pillar) => ({
+  pillar,
+  sections: Object.values(SITE_SECTIONS)
+    .filter((section) => section.pillar === pillar.key)
+    .map((section) => ({
+      label: section.label,
+      links: section.links.slice(0, 4),
+    })),
+}));
 
 const contactLinks = [
   { href: "https://github.com/enricopiovesan", label: "github" },
@@ -79,14 +56,21 @@ const contactLinks = [
       <div class="footer-bottom">
         <div class="footer-grid">
           {
-            sitemapColumns.map((column) => (
-              <div class="footer-cluster">
-                <h3>{column.heading}</h3>
-                <nav class="footer-links">
-                  {column.links.map((link) => (
-                    <a href={link.href}>{link.label}</a>
-                  ))}
-                </nav>
+            footerColumns.map((column) => (
+              <div class="footer-column">
+                <h3>
+                  <a href={column.pillar.href}>{column.pillar.label}</a>
+                </h3>
+                {column.sections.map((section) => (
+                  <div class="footer-cluster">
+                    {column.sections.length > 1 && <p class="footer-cluster__label">{section.label}</p>}
+                    <nav class="footer-links">
+                      {section.links.map((link) => (
+                        <a href={link.href}>{link.label}</a>
+                      ))}
+                    </nav>
+                  </div>
+                ))}
               </div>
             ))
           }
@@ -229,18 +213,38 @@ const contactLinks = [
 
   .footer-grid {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 13rem));
-    gap: 2rem;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 1.5rem;
+    flex: 1;
   }
 
-  .footer-cluster h3 {
-    margin: 0 0 0.75rem;
+  .footer-column h3 {
+    margin: 0 0 1rem;
     font-family: var(--font-mono);
     font-size: 0.75rem;
-    font-weight: 500;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.07em;
+  }
+
+  .footer-column h3 a {
     color: #201008;
+    text-decoration: none;
+  }
+
+  .footer-column h3 a:hover {
+    text-decoration: underline;
+  }
+
+  .footer-cluster + .footer-cluster {
+    margin-top: 1.25rem;
+  }
+
+  .footer-cluster__label {
+    margin: 0 0 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: rgba(32, 16, 8, 0.6);
   }
 
   .footer-links {
@@ -312,6 +316,10 @@ const contactLinks = [
     .footer-bottom {
       flex-direction: column;
       gap: 2.5rem;
+    }
+
+    .footer-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 
     .footer-meta {

--- a/book-website/src/components/Header.astro
+++ b/book-website/src/components/Header.astro
@@ -1,19 +1,12 @@
 ---
 import { withBase } from "../utils/url";
+import { PILLARS } from "../data/siteSections";
 
 interface Props {
   overlay?: boolean;
 }
 
 const { overlay = false } = Astro.props;
-
-const navItems = [
-  { href: withBase("/"), label: "Home" },
-  { href: withBase("/about-the-book/"), label: "About the Book" },
-  { href: withBase("/author/"), label: "Author" },
-  { href: withBase("/excerpt/"), label: "Excerpt" },
-  { href: withBase("/contact/"), label: "Contact" },
-];
 
 const currentPath = Astro.url.pathname;
 ---
@@ -26,9 +19,9 @@ const currentPath = Astro.url.pathname;
 
     <nav class="site-nav" aria-label="Primary">
       {
-        navItems.map((item) => (
-          <a href={item.href} aria-current={currentPath === item.href ? "page" : undefined}>
-            {item.label}
+        PILLARS.map((pillar) => (
+          <a href={pillar.href} aria-current={currentPath === pillar.href ? "page" : undefined}>
+            {pillar.label}
           </a>
         ))
       }

--- a/book-website/src/data/siteSections.ts
+++ b/book-website/src/data/siteSections.ts
@@ -9,18 +9,40 @@ export interface SiteSection {
   key: string;
   label: string;
   href: string;
+  pillar: string;
   links: SectionLink[];
 }
 
+export interface Pillar {
+  key: string;
+  label: string;
+  href: string;
+}
+
+// The site's top-level navigation, shown in the header and as the footer's
+// column headings. Every SiteSection below declares which pillar it rolls
+// up into, so the header/footer stay in sync with the section data instead
+// of hand-maintaining a second list.
+export const PILLARS: Pillar[] = [
+  { key: "book", label: "The Book", href: withBase("/about-the-book/") },
+  { key: "why-c-dad", label: "Why C-DAD", href: withBase("/why-c-dad/") },
+  { key: "model", label: "The Model", href: withBase("/core-model/") },
+  { key: "how-it-works", label: "How It Works", href: withBase("/how-c-dad-works/") },
+  { key: "for-ai-agents", label: "For AI Agents", href: withBase("/for-ai-agents/") },
+  { key: "proof", label: "Proof", href: withBase("/proof/") },
+];
+
 // Single source of truth for the site's information architecture: which
-// pages belong to which content cluster. Drives the left "section nav"
-// rail and the breadcrumb trail on every non-home page, so a page only
-// has to declare which section it's in, not repeat the link list.
+// pages belong to which content cluster, and which top-level pillar that
+// cluster rolls up into. Drives the left "section nav" rail and the
+// breadcrumb trail on every non-home page, so a page only has to declare
+// which section it's in, not repeat the link list.
 export const SITE_SECTIONS: Record<string, SiteSection> = {
   book: {
     key: "book",
     label: "The Book",
     href: withBase("/about-the-book/"),
+    pillar: "book",
     links: [
       { href: withBase("/about-the-book/"), label: "About the Book" },
       { href: withBase("/excerpt/"), label: "Free Excerpt" },
@@ -33,6 +55,7 @@ export const SITE_SECTIONS: Record<string, SiteSection> = {
     key: "chapters",
     label: "Chapters",
     href: withBase("/the-day-after/"),
+    pillar: "book",
     links: [
       { href: withBase("/the-day-after/"), label: "Ch.1: The Day After" },
       { href: withBase("/tribal-knowledge/"), label: "Ch.2: Tribal Knowledge Is the Bottleneck" },
@@ -56,6 +79,7 @@ export const SITE_SECTIONS: Record<string, SiteSection> = {
     key: "why-c-dad",
     label: "Why C-DAD",
     href: withBase("/why-c-dad/"),
+    pillar: "why-c-dad",
     links: [
       { href: withBase("/why-c-dad/"), label: "Why C-DAD" },
       { href: withBase("/why-c-dad/what-problem-does-c-dad-solve/"), label: "What problem does C-DAD solve?" },
@@ -68,6 +92,7 @@ export const SITE_SECTIONS: Record<string, SiteSection> = {
     key: "core-model",
     label: "Core Model",
     href: withBase("/core-model/"),
+    pillar: "model",
     links: [
       { href: withBase("/core-model/"), label: "Core Model" },
       { href: withBase("/core-model/legibility/"), label: "Legibility" },
@@ -75,6 +100,8 @@ export const SITE_SECTIONS: Record<string, SiteSection> = {
       { href: withBase("/core-model/contract/"), label: "Contract" },
       { href: withBase("/core-model/capability-graph/"), label: "Capability Graph" },
       { href: withBase("/core-model/minimum-viable-contract/"), label: "Minimum Viable Contract" },
+      { href: withBase("/core-model/extended-contract-fields/"), label: "Extended Contract Fields" },
+      { href: withBase("/core-model/contract-versioning/"), label: "Contract Versioning" },
       { href: withBase("/core-model/contract-anti-patterns/"), label: "Contract Anti-Patterns" },
       { href: withBase("/core-model/capability-lifecycle-states/"), label: "Capability Lifecycle States" },
     ],
@@ -83,6 +110,7 @@ export const SITE_SECTIONS: Record<string, SiteSection> = {
     key: "how-c-dad-works",
     label: "How C-DAD Works",
     href: withBase("/how-c-dad-works/"),
+    pillar: "how-it-works",
     links: [
       { href: withBase("/how-c-dad-works/"), label: "How C-DAD Works" },
       { href: withBase("/how-c-dad-works/cdad-check/"), label: "cdad check" },
@@ -97,6 +125,7 @@ export const SITE_SECTIONS: Record<string, SiteSection> = {
     key: "glossary",
     label: "Glossary",
     href: withBase("/glossary/"),
+    pillar: "model",
     links: [
       { href: withBase("/glossary/"), label: "Glossary" },
       { href: withBase("/glossary/legibility/"), label: "Legibility" },
@@ -111,10 +140,26 @@ export const SITE_SECTIONS: Record<string, SiteSection> = {
       { href: withBase("/glossary/non-goals/"), label: "Non-Goals" },
     ],
   },
+  "for-ai-agents": {
+    key: "for-ai-agents",
+    label: "For AI Agents",
+    href: withBase("/for-ai-agents/"),
+    pillar: "for-ai-agents",
+    links: [
+      { href: withBase("/for-ai-agents/"), label: "For AI Agents" },
+      { href: withBase("/for-ai-agents/contract-aware-coding-agent/"), label: "The Contract-Aware Coding Agent" },
+      { href: withBase("/for-ai-agents/contract-author/"), label: "The Contract Author" },
+      { href: withBase("/for-ai-agents/contract-reviewer/"), label: "The Contract Reviewer" },
+      { href: withBase("/for-ai-agents/legibility-auditor/"), label: "The Legibility Auditor" },
+      { href: withBase("/for-ai-agents/extraction-agent/"), label: "The Extraction Agent" },
+      { href: withBase("/for-ai-agents/contract-maintenance-agent/"), label: "The Contract Maintenance Agent" },
+    ],
+  },
   comparisons: {
     key: "comparisons",
     label: "Comparisons",
     href: withBase("/comparisons/"),
+    pillar: "proof",
     links: [
       { href: withBase("/comparisons/"), label: "Comparisons" },
       { href: withBase("/comparisons/c-dad-vs-documentation/"), label: "C-DAD vs Documentation" },
@@ -128,6 +173,7 @@ export const SITE_SECTIONS: Record<string, SiteSection> = {
     key: "use-cases",
     label: "Use Cases",
     href: withBase("/use-cases/"),
+    pillar: "proof",
     links: [
       { href: withBase("/use-cases/"), label: "Use Cases" },
       { href: withBase("/use-cases/legacy-codebase-modernization/"), label: "Legacy Codebase Modernization" },
@@ -141,6 +187,7 @@ export const SITE_SECTIONS: Record<string, SiteSection> = {
     key: "proof",
     label: "Proof",
     href: withBase("/proof/"),
+    pillar: "proof",
     links: [
       { href: withBase("/proof/"), label: "Proof" },
       { href: withBase("/proof/legibility-scoring-methodology/"), label: "Legibility Scoring Methodology" },
@@ -152,6 +199,7 @@ export const SITE_SECTIONS: Record<string, SiteSection> = {
     key: "examples",
     label: "Examples",
     href: withBase("/examples/"),
+    pillar: "proof",
     links: [
       { href: withBase("/examples/"), label: "Examples" },
       { href: withBase("/examples/payment-retry-policy-contract/"), label: "Payment Retry Policy Contract" },
@@ -164,6 +212,7 @@ export const SITE_SECTIONS: Record<string, SiteSection> = {
     key: "toolkit",
     label: "Toolkit",
     href: withBase("/toolkit/"),
+    pillar: "how-it-works",
     links: [
       { href: withBase("/toolkit/"), label: "Toolkit" },
       { href: withBase("/toolkit/installation/"), label: "Installation" },

--- a/book-website/src/layouts/BaseLayout.astro
+++ b/book-website/src/layouts/BaseLayout.astro
@@ -17,6 +17,8 @@ const {
 } = Astro.props;
 
 const pageTitle = title === "The Day After AI" ? title : `${title}: The Day After AI`;
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const ogImageURL = new URL(withBase("/images/hero.jpg"), Astro.site);
 ---
 
 <html lang="en">
@@ -25,6 +27,7 @@ const pageTitle = title === "The Day After AI" ? title : `${title}: The Day Afte
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalURL} />
     <link rel="icon" type="image/svg+xml" href={withBase("/favicon.svg")} />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -33,6 +36,17 @@ const pageTitle = title === "The Day After AI" ? title : `${title}: The Day Afte
       rel="stylesheet"
     />
     <title>{pageTitle}</title>
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="The Day After AI" />
+    <meta property="og:title" content={pageTitle} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalURL} />
+    <meta property="og:image" content={ogImageURL} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={pageTitle} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImageURL} />
     <script is:inline>
       // Applied before paint to avoid a flash of the wrong theme.
       const stored = localStorage.getItem("theme");

--- a/book-website/src/pages/appendix.astro
+++ b/book-website/src/pages/appendix.astro
@@ -31,9 +31,8 @@ const toc = [
     </p>
     <p>
       The appendix hands over three of them, each built against the same
-      running example from the book, the payment retry policy from
-      Meridian's payments domain, the capability that opens the book and
-      never really leaves it.
+      running example from the book, `payment/retry`, the capability
+      that opens the book and never really leaves it.
     </p>
   </section>
 

--- a/book-website/src/pages/appendix/contract-schema-reference.astro
+++ b/book-website/src/pages/appendix/contract-schema-reference.astro
@@ -15,9 +15,9 @@ import { withBase } from "../../utils/url";
   <p>
     Understanding what a contract is and knowing how to write one are
     different things. This is the artifact that closes that gap: two
-    schemas, both shown against the same capability, the payment retry
-    policy from Meridian's payments domain that runs through the whole
-    book as the example of what undeclared knowledge actually costs.
+    schemas, both shown against the same capability, `payment/retry`,
+    the toolkit's own real worked example of what undeclared knowledge
+    actually costs.
   </p>
   <p>
     The <strong>minimum viable contract</strong> is the starting

--- a/book-website/src/pages/core-model.astro
+++ b/book-website/src/pages/core-model.astro
@@ -35,10 +35,12 @@ const toc = [
       being diagnosed, and contract defines what you write down once
       you've decided a capability is worth the effort. The capability
       graph is what you get when contracts accumulate across a whole
-      system. The last three pages are more operational: the minimum
-      fields a contract actually needs, the specific ways contracts
-      drift when nobody's watching, and the arc a capability travels
-      from invisible logic to something a contract governs.
+      system. The rest of the pages are more operational: the minimum
+      fields a contract needs, the extended fields for capabilities
+      that carry more risk, how a contract's version number actually
+      gets decided, the specific ways contracts drift when nobody's
+      watching, and the arc a capability travels from invisible logic
+      to something a contract governs.
     </p>
   </section>
 
@@ -64,6 +66,14 @@ const toc = [
       <li>
         <a href={withBase("/core-model/minimum-viable-contract/")}>Minimum Viable Contract</a>
         <p>The exact fields a contract needs to be useful, no more and no less, field by field.</p>
+      </li>
+      <li>
+        <a href={withBase("/core-model/extended-contract-fields/")}>Extended Contract Fields</a>
+        <p>Dependencies, performance, error handling, trust zones, constraint history: the fields for capabilities carrying real operational weight.</p>
+      </li>
+      <li>
+        <a href={withBase("/core-model/contract-versioning/")}>Contract Versioning</a>
+        <p>Why a version bump is decided by downstream compatibility, not by how large the text diff looks.</p>
       </li>
       <li>
         <a href={withBase("/core-model/contract-anti-patterns/")}>Contract Anti-Patterns</a>

--- a/book-website/src/pages/core-model/contract-anti-patterns.astro
+++ b/book-website/src/pages/core-model/contract-anti-patterns.astro
@@ -115,7 +115,7 @@ import { withBase } from "../../utils/url";
   <BuyLinks />
 
   <nav class="chapter-nav" aria-label="Related pages">
-    <a href={withBase("/core-model/minimum-viable-contract/")}>&larr; Minimum Viable Contract</a>
+    <a href={withBase("/core-model/contract-versioning/")}>&larr; Contract Versioning</a>
     <a href={withBase("/core-model/capability-lifecycle-states/")}>Capability Lifecycle States &rarr;</a>
   </nav>
 </SubpageLayout>

--- a/book-website/src/pages/core-model/contract-versioning.astro
+++ b/book-website/src/pages/core-model/contract-versioning.astro
@@ -1,0 +1,102 @@
+---
+import SubpageLayout from "../../layouts/SubpageLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<SubpageLayout
+  title="Contract Versioning"
+  description="Semantic versioning for contracts follows three rules, and the decision behind a version bump has nothing to do with how large the text diff looks."
+  section="core-model"
+>
+  <h1>Contract Versioning</h1>
+
+  <p>
+    A contract's `version` field uses standard semantic versioning,
+    major, minor, patch, and the toolkit is deliberate about what
+    decides which number moves. It's not the size of the diff. A
+    one-line change to a guarantee can be a major break. A twenty-line
+    addition of new optional fields can be a minor bump. What decides
+    the version is downstream compatibility: does a capability that
+    depends on this one need to change anything to stay correct.
+  </p>
+  <p>
+    A major version moves when a change breaks a dependent capability
+    or removes a guarantee the contract used to make. Tightening a
+    response guarantee that makes a previous caller's assumption
+    invalid counts, even if nothing about the request shape changed.
+    The test isn't whether the API signature looks different. It's
+    whether something that used to be true, and that another
+    capability was relying on, stops being true.
+  </p>
+  <p>
+    A minor version moves when a change adds backward-compatible
+    fields, capabilities, or clarifications without invalidating
+    anything a current caller depends on. Adding a new optional
+    dependency with its rationale documented is the canonical minor
+    change: it expands what the capability can do without narrowing
+    what it already promised. Existing callers keep working exactly
+    as they did before the bump.
+  </p>
+  <p>
+    A patch version moves when the change only corrects the contract
+    text itself without touching declared behavior. Fixing an
+    ambiguous description so it says what was always true, but said
+    imprecisely, is a patch. Nothing about how the capability actually
+    behaves changes. Only the accuracy of what's written about it
+    does.
+  </p>
+  <p>
+    In practice this comes down to three questions, asked in order.
+    Would a dependent capability need to change behavior or
+    assumptions to stay correct? If yes, that's major, full stop,
+    regardless of how the other two questions answer. Did the change
+    add expressive power without invalidating existing consumers? If
+    that's the only yes, it's minor. Did the change only clarify
+    wording, examples, or metadata without touching the behavioral
+    contract itself? If that's the only yes, it's patch.
+  </p>
+  <p>
+    The reason this discipline matters more for contracts than for
+    typical application code is that a contract's version isn't
+    describing an implementation detail. It's describing a promise,
+    and every capability that declared a dependency on a specific
+    version range is trusting that promise to hold. Bump carelessly
+    and an agent reading a stale version constraint will trust
+    guarantees that no longer exist. The contract-maintenance role
+    exists specifically to catch this kind of drift before it reaches
+    that point, comparing the current contract against the code, the
+    generated `contract.json` and `contract.md` siblings, and flagging
+    exactly which field is out of date and which version bump the fix
+    actually calls for.
+  </p>
+
+  <BuyLinks />
+
+  <nav class="chapter-nav" aria-label="Related pages">
+    <a href={withBase("/core-model/extended-contract-fields/")}>&larr; Extended Contract Fields</a>
+    <a href={withBase("/core-model/contract-anti-patterns/")}>Contract Anti-Patterns &rarr;</a>
+  </nav>
+</SubpageLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/core-model/extended-contract-fields.astro
+++ b/book-website/src/pages/core-model/extended-contract-fields.astro
@@ -1,0 +1,124 @@
+---
+import SubpageLayout from "../../layouts/SubpageLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<SubpageLayout
+  title="Extended Contract Fields"
+  description="Dependencies, performance, error handling, trust zones, rate limits, constraint history. The fields that turn a minimum viable contract into a full operational record, and when a capability actually needs them."
+  section="core-model"
+>
+  <h1>Extended Contract Fields</h1>
+
+  <p>
+    The minimum viable contract answers what a capability does, why,
+    and where its edges are. That's enough for most capabilities most
+    of the time. Some capabilities carry more weight than that,
+    payment paths, anything with a hard performance floor, anything
+    that's already caused an incident, and for those the toolkit
+    defines an extended schema that layers operational detail on top
+    of the same eleven required fields. Nothing in the minimum
+    contract disappears. The extended fields are additive, and a
+    capability only needs them when the risk actually justifies the
+    extra weight.
+  </p>
+  <p>
+    `dependencies` names every upstream capability this one relies
+    on, with a version constraint and, critically, the reason the
+    constraint exists. `payment/processor/status` at `>=2.1.0` isn't
+    useful on its own. What makes it useful is the sentence next to
+    it explaining that earlier versions didn't expose in-flight
+    transaction state, which is the specific thing that makes a safe
+    retry decision possible at all. Strip the rationale and the
+    version number turns back into trivia nobody can safely change.
+  </p>
+  <p>
+    `performance` declares response time and throughput thresholds,
+    and the schema pushes past a bare number to the reasoning behind
+    it. A 500ms p99 target means little by itself. It means something
+    once the contract explains that the threshold assumes a
+    downstream status check completes in under 400ms, and that
+    raising the threshold requires renegotiating with whoever owns
+    that downstream call first. `error_handling` does the equivalent
+    work for failure paths: not just what error code comes back, but
+    what the capability does about it and why that response was
+    chosen over the alternative. A false negative that blocks a safe
+    action can be an acceptable tradeoff. A false positive that
+    allows an unsafe one usually isn't, and the contract is where
+    that asymmetry gets written down instead of assumed.
+  </p>
+  <p>
+    `trust_zone` states plainly whether a capability is internal,
+    external, or privileged, which matters enormously to an agent
+    deciding whether a proposed change is even in scope for it to
+    make unsupervised. `rate_limits` records the ceiling and burst
+    allowance a capability enforces, along with where that number
+    came from, inherited from a platform-wide policy, set below a
+    downstream service's own limit to leave headroom, or something
+    else. A rate limit without its rationale is just a number someone
+    will eventually treat as arbitrary and change.
+  </p>
+  <p>
+    `inherited_constraints` captures policy that flows down from
+    somewhere above this capability rather than originating here,
+    keeping the source of a rule visible instead of letting it look
+    locally invented. `constraint_history` is the field that does the
+    most work against tribal knowledge specifically: it preserves the
+    actual incidents that shaped the capability, dated, with the
+    lesson stated explicitly, not just logged as an event but written
+    as the constraint a future maintainer has to preserve. A
+    production incident that cost real money and taught a real lesson
+    is exactly the kind of knowledge that otherwise survives only in
+    the memory of whoever was on call that day.
+  </p>
+  <p>
+    The remaining fields track how a capability changes over time.
+    `deprecation_timeline` and `migration_path` describe how a
+    capability winds down and what replaces it. `versioning_strategy`
+    and `version_history` keep the semantic versioning decisions
+    themselves legible, not just the current version number but the
+    reasoning trail that produced it. Together they mean a capability's
+    evolution stays readable years after the people who made those
+    decisions have moved on to something else.
+  </p>
+  <p>
+    The rule that governs every extended field is the same rule that
+    governs the minimum ones: write intent, guarantees, and history in
+    plain language, and if a field starts describing retries, caches,
+    queues, or backoff timers just because that's how the capability
+    happens to be implemented today, rewrite it toward the business
+    rule that actually justifies the behavior. Scaffold the extended
+    form with `cdad init &lt;capability-id&gt; --extended` once a
+    capability's risk profile earns the extra fields, not before.
+  </p>
+
+  <BuyLinks />
+
+  <nav class="chapter-nav" aria-label="Related pages">
+    <a href={withBase("/core-model/minimum-viable-contract/")}>&larr; Minimum Viable Contract</a>
+    <a href={withBase("/core-model/contract-versioning/")}>Contract Versioning &rarr;</a>
+  </nav>
+</SubpageLayout>
+
+<style>
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/core-model/minimum-viable-contract.astro
+++ b/book-website/src/pages/core-model/minimum-viable-contract.astro
@@ -122,7 +122,7 @@ import { withBase } from "../../utils/url";
 
   <nav class="chapter-nav" aria-label="Related pages">
     <a href={withBase("/core-model/capability-graph/")}>&larr; Capability Graph</a>
-    <a href={withBase("/core-model/contract-anti-patterns/")}>Contract Anti-Patterns &rarr;</a>
+    <a href={withBase("/core-model/extended-contract-fields/")}>Extended Contract Fields &rarr;</a>
   </nav>
 </SubpageLayout>
 

--- a/book-website/src/pages/examples/payment-retry-policy-contract.astro
+++ b/book-website/src/pages/examples/payment-retry-policy-contract.astro
@@ -6,58 +6,103 @@ import { withBase } from "../../utils/url";
 
 <SubpageLayout
   title="Payment Retry Policy Contract"
-  description="The payment retry policy from Meridian's payments domain is the example that runs through the whole book. Here's what a real contract for it would actually need to say."
+  description="The toolkit's own real worked example: payment/retry, the capability that opens the book. What its minimum viable contract says, what the extended version adds, and the real incident that made the extra fields necessary."
   section="examples"
 >
   <h1>Payment Retry Policy Contract</h1>
 
   <p>
-    The running example throughout the book, and in the appendix's
-    schema reference, is the payment retry policy from Meridian's
-    payments domain. It's a good example precisely because it's not
-    exotic. Every team with a payments surface has some version of it:
-    code that decides whether to try charging a customer again after a
-    failure, and how many times, and under what conditions it should
-    stop trying.
+    The running example throughout the book, and in the toolkit's own
+    templates, is a capability called `payment/retry`, owned by a
+    payments team. What it does sounds simple: decide whether a failed
+    payment attempt is safe to retry. What makes it a good teaching
+    example is that the simple description hides a constraint that
+    isn't obvious from the code, and that constraint is exactly what a
+    contract exists to preserve.
   </p>
   <p>
-    A contract for that capability doesn't start with implementation
-    detail. It starts with what the capability does, described in
-    plain language a new engineer or an agent can act on without
-    reading the retry loop line by line: it decides whether and when
-    to retry a failed payment attempt, and what happens once retries
-    are exhausted.
+    The minimum viable version states the capability plainly. It
+    retries a failed payment attempt only after confirming the
+    upstream payment processor has not yet received, or is not
+    currently processing, the original request. It exists because the
+    processor used in production doesn't honor idempotency keys until
+    a transaction finishes processing, which means a naive retry fired
+    while the original request is still in flight results in a
+    duplicate charge. That sentence alone is the entire reason this
+    capability needs to exist as its own contracted unit rather than
+    a few lines buried inside a larger payment flow.
   </p>
   <p>
-    Then it says why. This is the part most codebases never write
-    down. Retries aren't attempted on every failure the same way,
-    because some failures mean the card was declined and trying again
-    immediately just annoys the customer, while others mean the
-    gateway timed out and the original charge may or may not have gone
-    through. The contract states that distinction instead of leaving
-    it as something only the engineer who wrote the original ticket
-    remembers.
+    It needs a `payment_id`, which has to be the original ID from the
+    failed attempt, never a freshly generated one, because the
+    processor uses that field to detect duplicate attempts once
+    idempotency keys are active. It needs a `retry_reason`, restricted
+    to `network_timeout`, `processor_unavailable`, or `rate_limited`,
+    explicitly excluding declined payments, which the contract states
+    is a different capability's problem, not this one's. It promises a
+    `retry_status` that only reports `confirmed_safe_to_retry` after
+    explicit confirmation from the processor's status endpoint, never
+    inferred from a timeout. And it draws a hard boundary: this
+    capability assesses retry safety and returns a status. It does not
+    initiate the retry itself, does not touch declined payments, and
+    does not modify the original payment record. Three sentences, and
+    a future engineer or agent now knows exactly where this
+    capability's authority ends.
   </p>
   <p>
-    It also declares what the capability needs: which upstream signal
-    tells it a charge is safe to retry, what idempotency guarantee it
-    depends on so a retry can't double-charge someone, and what
-    configuration or account state it reads before deciding to try
-    again. It declares what it promises: a bounded number of attempts,
-    a predictable backoff shape, a final state the rest of the system
-    can rely on once retries stop. And it declares what it explicitly
-    doesn't do, which matters just as much. It doesn't decide refund
-    policy, it doesn't touch dispute handling, and it doesn't retry
-    past the point where the payment provider has told it to stop.
-    Leaving that boundary unstated is exactly how a capability quietly
-    grows scope nobody signed up for.
+    The extended version of the same contract is where the real story
+    lives, in a field called `constraint_history`. On March 14, 2022,
+    a production incident happened because the retry logic called the
+    processor directly without checking in-flight status first. The
+    processor was still processing the original request when the
+    retry arrived. Forty-seven customers were charged twice. Refunds
+    went out the same day. The revenue impact was twenty-three
+    thousand dollars, and it triggered an SLA breach with two
+    enterprise customers. The lesson, confirmed by the processor's own
+    support team in ticket PRO-8821, is that the processor doesn't
+    honor idempotency keys until processing completes, a fact that
+    isn't in the processor's public documentation at all. Any retry
+    implementation has to check in-flight status explicitly, and that
+    requirement is now written into the contract instead of living
+    only in the memory of whoever handled the incident.
   </p>
   <p>
-    None of that requires reproducing a full schema here. The point of
-    walking through it in prose is to show that a contract isn't
-    paperwork bolted onto working code. It's the part of the
-    capability that was always true, made readable to whoever, or
-    whatever, has to change it next.
+    The extended contract also declares the dependency this capability
+    can't function without: `payment/processor/status` at version
+    2.1.0 or later, with the rationale attached directly. Earlier
+    versions of that capability didn't expose in-flight transaction
+    state, which made a safe retry decision impossible to make at all.
+    Nobody is meant to relax that version constraint without first
+    confirming an alternative detection method with the payments team,
+    and the contract says so explicitly rather than leaving it to be
+    rediscovered the hard way a second time.
+  </p>
+  <p>
+    Performance and rate limits carry their own reasoning too. The
+    p99 response target is 500 milliseconds, bounded by the
+    processor's own status-check latency, and the contract notes that
+    the threshold assumes that check completes in under 400
+    milliseconds, so any renegotiation of processor latency has to
+    happen before the timeout changes. The rate limit is set to thirty
+    requests per minute with a burst allowance of five, deliberately
+    half of the processor's own sixty-per-minute ceiling, to leave
+    headroom for every other caller hitting that same status endpoint.
+    And the error handling rule is asymmetric on purpose: if the
+    processor's status can't be confirmed, the capability returns
+    `unsafe` and blocks the retry. A false negative that blocks a safe
+    retry is an acceptable cost. A false positive that allows an
+    unsafe one is not, and the contract states that tradeoff instead
+    of leaving it as an assumption baked into a conditional somewhere.
+  </p>
+  <p>
+    None of this is hypothetical or dressed up for the page. It's the
+    actual worked example shipped in the toolkit's templates, the same
+    one the appendix's schema reference walks through field by field.
+    The point of showing it in full is that a contract isn't
+    paperwork bolted onto working code after the fact. It's the
+    incident, the dependency, and the boundary that were always true,
+    made readable to whoever, or whatever, has to touch this
+    capability next.
   </p>
 
   <BuyLinks />

--- a/book-website/src/pages/for-ai-agents/contract-author.astro
+++ b/book-website/src/pages/for-ai-agents/contract-author.astro
@@ -1,0 +1,113 @@
+---
+import SubpageLayout from "../../layouts/SubpageLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<SubpageLayout
+  title="The Contract Author"
+  description="A role prompt that turns business intent into a complete contract.yaml. It asks for capability ID, intent, inputs, outputs, non-goals, and history, and never for implementation detail."
+  section="for-ai-agents"
+>
+  <h1>The Contract Author</h1>
+
+  <p>
+    The contract author's job is narrower than "help me write a
+    contract." It helps a practitioner produce a
+    <code>contract.yaml</code> that is machine-readable, precise, and
+    complete enough to pass <code>cdad validate</code> once it's
+    written into a scaffolded file. It's grounded in
+    <code>docs/contract-schema-reference.md</code>, the minimum viable
+    contract schema, and the toolkit's own templates, including the
+    payment-retry worked example, so the YAML it produces matches the
+    schema the CLI actually checks against, not a generic idea of what
+    a contract should look like.
+  </p>
+  <p>
+    The order it works in is deliberate. It asks for the capability ID
+    first, in the <code>domain/subdomain/action</code> semantic naming
+    format the schema expects, and checks whether the practitioner has
+    already run <code>cdad init &lt;capability-id&gt;</code>. If not,
+    it explains that the toolkit can scaffold
+    <code>contract.yaml</code>, <code>contract.json</code>, and
+    <code>contract.md</code> automatically rather than starting from a
+    blank file. From there it asks for the business intent, what the
+    capability does and why it exists, then the inputs and outputs,
+    then the non-goals, then any known constraints or history: what's
+    gone wrong before, what workarounds exist, what tribal knowledge
+    would otherwise walk out the door with whoever's answering these
+    questions.
+  </p>
+  <p>
+    What it deliberately doesn't ask for is implementation detail. If a
+    practitioner answers in implementation language anyway, "we cache
+    the result for 90 seconds," the contract author's job is to surface
+    the business rule underneath that sentence and write that down
+    instead of transcribing the caching decision verbatim. It's also
+    watching for signs that a capability needs more than the minimum
+    schema can hold. If dependency, performance, error-handling, or
+    evolution context clearly belongs in the same artifact, it tells
+    the practitioner to scaffold the extended form with
+    <code>cdad init &lt;capability-id&gt; --extended</code> before
+    continuing, rather than cramming that context into fields that
+    weren't built for it.
+  </p>
+  <p>
+    The output is YAML with every field populated, no placeholders, and
+    no implementation language sitting in the description field.
+    <code>non_goals</code> can't be left empty, every input needs a
+    business constraint attached, every output needs a guarantee, and
+    <code>open_questions</code> has to be honest, meaning it becomes an
+    empty list before the capability's state can honestly move to
+    <code>active</code>. After producing the contract, it reminds the
+    practitioner to run <code>cdad validate
+    [path/to/contract.yaml]</code>, because writing a contract that
+    reads well isn't the same as writing one that validates.
+  </p>
+  <p>
+    In the adoption loop, this is the prompt that sits inside
+    <code>cdad init</code>. Something has already been chosen for
+    extraction, likely by the legibility auditor and the extraction
+    agent working together, and now someone has to turn that decision
+    into an actual artifact. The contract author is what fills in the
+    scaffold. What it hands off next is a draft for the contract
+    reviewer to check before anything gets merged.
+  </p>
+
+  <BuyLinks />
+
+  <nav class="chapter-nav" aria-label="Related pages">
+    <a href={withBase("/for-ai-agents/contract-aware-coding-agent/")}>&larr; The Contract-Aware Coding Agent</a>
+    <a href={withBase("/for-ai-agents/contract-reviewer/")}>The Contract Reviewer &rarr;</a>
+  </nav>
+</SubpageLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/for-ai-agents/contract-aware-coding-agent.astro
+++ b/book-website/src/pages/for-ai-agents/contract-aware-coding-agent.astro
@@ -1,0 +1,114 @@
+---
+import SubpageLayout from "../../layouts/SubpageLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<SubpageLayout
+  title="The Contract-Aware Coding Agent"
+  description="The implementation prompt for a repository where contracts define intent. It checks the relevant contract before touching code and stops when the contract and the code disagree."
+  section="for-ai-agents"
+>
+  <h1>The Contract-Aware Coding Agent</h1>
+
+  <p>
+    Five of the toolkit's role prompts operate on contracts and audits.
+    This one is the exception: it's the prompt that actually edits
+    application code, and it does that work inside a repository where a
+    contract, when one exists, is the governing source of intent rather
+    than a document sitting next to the code for reference. Before it
+    touches anything, it checks the relevant contract under
+    <code>cdad/</code>, reads <code>docs/cli-reference.md</code> for
+    intended command behavior, checks
+    <code>ref/the-day-after-toolkit-spec.md</code> for governing spec
+    language, and looks at whatever generated artifacts the change
+    would affect, things like <code>cdad-report.md</code>,
+    <code>cdad-roadmap.md</code>, or <code>cdad-graph.json</code>.
+  </p>
+  <p>
+    If no contract exists for the capability it's about to touch, it
+    says so explicitly instead of quietly proceeding. That distinction
+    matters more than it looks like it does. An agent that infers
+    intent from code structure alone is guessing at business rules it
+    has no way to verify, and it will guess wrong in exactly the cases
+    that matter most: the retry limit that exists because of a past
+    incident, the ordering that looks arbitrary but isn't. This prompt
+    is meant to be paired with the repository's <code>CLAUDE.md</code>
+    context file, which carries the same discipline at the repo level:
+    never modify a capability in a way that violates its declared
+    non-goals, never remove a behavioral constraint without updating
+    the contract, and if a constraint shows up in the code but isn't in
+    the contract, surface it rather than assume it was intentional.
+  </p>
+  <p>
+    Its working rules are narrow on purpose. It never widens behavior
+    beyond what a contract says unless it updates that contract first.
+    When it changes behavior, it updates the closest supporting docs or
+    tests in the same slice of work, so the repository doesn't drift
+    out of sync with itself one commit at a time. When it does change a
+    contract, it treats <code>contract.yaml</code> as the source of
+    truth and keeps <code>contract.json</code> and
+    <code>contract.md</code> synchronized before anything gets
+    validated. And if the contract, the spec, and the implementation
+    disagree with each other, it stops. It surfaces the mismatch rather
+    than picking whichever version seems most plausible and coding
+    around the disagreement.
+  </p>
+  <p>
+    Verification is concrete rather than vibes-based: run
+    <code>npm test</code> for CLI or library changes, run
+    <code>cdad validate &lt;path&gt;</code> whenever a contract changed,
+    and run <code>cdad graph</code> when the change touched dependency
+    coverage or topology. That's the same validation surface a human
+    contributor would be expected to run, which is the point. The
+    contract-aware coding agent isn't held to a lighter bar than a
+    practitioner working the same repository, it's held to the same
+    one, expressed as instructions it can actually follow without a
+    person standing over its shoulder.
+  </p>
+  <p>
+    This is the prompt you reach for once a capability already has a
+    contract and someone, human or agent, needs to change the code
+    underneath it. The other five role prompts exist to get a
+    capability to that point: authored, reviewed, audited, sequenced,
+    and kept in sync. This one is what happens after, on every ordinary
+    day of implementation work that follows.
+  </p>
+
+  <BuyLinks />
+
+  <nav class="chapter-nav" aria-label="Related pages">
+    <a href={withBase("/for-ai-agents/")}>&larr; For AI Agents</a>
+    <a href={withBase("/for-ai-agents/contract-author/")}>The Contract Author &rarr;</a>
+  </nav>
+</SubpageLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/for-ai-agents/contract-maintenance-agent.astro
+++ b/book-website/src/pages/for-ai-agents/contract-maintenance-agent.astro
@@ -1,0 +1,110 @@
+---
+import SubpageLayout from "../../layouts/SubpageLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<SubpageLayout
+  title="The Contract Maintenance Agent"
+  description="A role prompt that finds drift between contract.yaml, the code, and its generated json and markdown siblings, then names the exact field and semver bump needed to fix it."
+  section="for-ai-agents"
+>
+  <h1>The Contract Maintenance Agent</h1>
+
+  <p>
+    A contract that was accurate on the day it was written can go stale
+    without anyone deciding to let it. Code gets patched, an edge case
+    gets handled, a guarantee quietly stops holding, and the contract
+    sitting next to all of that doesn't update itself. The contract
+    maintenance agent's job is to find that drift: between
+    <code>contract.yaml</code>, the current code and tests, the
+    generated siblings <code>contract.json</code> and
+    <code>contract.md</code>, and any other repo-level artifact that
+    changed the capability's context. It's specifically watching for
+    stale assumptions sitting in <code>constraint_history</code>,
+    behavior that's been added but never captured, and guarantees the
+    implementation no longer actually meets.
+  </p>
+  <p>
+    It works in a fixed sequence: identify the capability path and read
+    <code>contract.yaml</code> first, before looking at anything else.
+    Compare that contract against the current code, tests, and docs
+    that shape how the capability behaves. Flag any missing contract
+    updates before suggesting implementation changes, because fixing
+    the code first and the contract later is exactly the order that
+    lets drift compound. If <code>contract.yaml</code> changes, it
+    requires <code>contract.json</code> and <code>contract.md</code> to
+    be re-synced before the work counts as finished, and it tells the
+    practitioner to run <code>cdad validate &lt;path&gt;</code>
+    afterward, plus <code>cdad validate --all --strict</code> before
+    merge whenever the repository holds more than one contract.
+  </p>
+  <p>
+    The part of this prompt that does the most practical work is its
+    versioning rule. When a contract is outdated, it names the exact
+    field that needs revision and the version bump that fits it:
+    <code>PATCH</code> for clarifications or documentation-only
+    corrections that don't change runtime expectations,
+    <code>MINOR</code> for backward-compatible additions like a new
+    optional input, output, or constraint, and <code>MAJOR</code> for
+    removed guarantees, breaking behavioral changes, stricter
+    requirements, or dependency shifts that could break whatever
+    depends on this capability. That's a meaningfully harder judgment
+    than most changelog conventions ask for, because it requires
+    actually understanding what the contract promised before deciding
+    how badly a change breaks that promise.
+  </p>
+  <p>
+    Its output always follows the same shape: the drift findings first,
+    then the exact contract fields that must change, then the version
+    bump recommendation, then the specific validation command the
+    practitioner should run next. Nothing here is left as a vague
+    "you might want to update this."
+  </p>
+  <p>
+    This is the maintenance layer that keeps the rest of the model
+    honest over time. A capability that scored well on its legibility
+    audit the day it was contracted can quietly slide backward if
+    nobody's watching for drift, which is a large part of why
+    <code>cdad check</code> is meant to run again and again. The
+    contract maintenance agent is what closes that loop between one
+    check and the next, before the gap gets big enough to matter.
+  </p>
+
+  <BuyLinks />
+
+  <nav class="chapter-nav" aria-label="Related pages">
+    <a href={withBase("/for-ai-agents/extraction-agent/")}>&larr; The Extraction Agent</a>
+    <a href={withBase("/for-ai-agents/")}>For AI Agents &rarr;</a>
+  </nav>
+</SubpageLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/for-ai-agents/contract-reviewer.astro
+++ b/book-website/src/pages/for-ai-agents/contract-reviewer.astro
@@ -1,0 +1,105 @@
+---
+import SubpageLayout from "../../layouts/SubpageLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<SubpageLayout
+  title="The Contract Reviewer"
+  description="A role prompt that reviews a contract in a fixed order: missing fields, implementation language, unsupported claims, missing constraints, then state mismatches. It never approves on polish alone."
+  section="for-ai-agents"
+>
+  <h1>The Contract Reviewer</h1>
+
+  <p>
+    A contract can read beautifully and still be wrong for the
+    repository it describes. The contract reviewer exists because
+    "sounds polished" and "is accurate" aren't the same test, and the
+    prompt is explicit about reviewing against the real toolkit rather
+    than a generic contract-writing standard: <code>docs/contract-schema-reference.md</code>,
+    <code>docs/cli-reference.md</code>, both the minimum viable and
+    extended schemas, and the payment-retry worked example as a
+    reference for what a good one actually looks like.
+  </p>
+  <p>
+    The review runs in a fixed order, and the order isn't arbitrary. It
+    starts with missing required fields or invalid field shapes,
+    because a contract that can't validate at all makes everything
+    after it moot. Next comes implementation language disguised as
+    intent, the description field explaining how something works
+    instead of why it exists. Then claims that aren't supported by the
+    current repo, spec, or generated artifacts, which catches
+    contracts that describe an aspirational system rather than the one
+    that's actually running. Fourth is missing business constraints,
+    non-goals, or rationale that the next practitioner would need and
+    won't have. Last comes state mismatches, in particular a contract
+    marked <code>state: active</code> while it still has unresolved
+    <code>open_questions</code>, which is a subtle way for a contract
+    to claim more confidence than it's earned.
+  </p>
+  <p>
+    For every problem it finds, it explains three things: what should
+    change, why it matters to the next practitioner who reads this
+    contract without any of the context the author had, and whether the
+    issue is likely to fail <code>cdad validate</code> outright or just
+    quietly weaken legibility without breaking the schema. That third
+    point is what keeps the review useful instead of just pedantic.
+    Some problems are blocking. Others are the kind of thing that
+    technically validates but leaves a future reader, human or agent,
+    guessing at something they shouldn't have to guess at.
+  </p>
+  <p>
+    The review rule underneath all of it is stated plainly in the
+    prompt: don't approve a contract because it sounds polished.
+    Approve it only when the artifact actually makes the capability
+    easier to navigate without reverse-engineering the implementation.
+    That's a higher bar than most code review checklists set, and it's
+    the right bar for an artifact whose entire purpose is letting
+    someone act on a capability without having to read the code
+    underneath it first.
+  </p>
+  <p>
+    This prompt runs before contract changes get merged, right after
+    the contract author has produced a draft. It's the checkpoint that
+    keeps the extraction loop honest: a contract that passes this
+    review is one an agent can act on later without silently inheriting
+    a gap nobody caught.
+  </p>
+
+  <BuyLinks />
+
+  <nav class="chapter-nav" aria-label="Related pages">
+    <a href={withBase("/for-ai-agents/contract-author/")}>&larr; The Contract Author</a>
+    <a href={withBase("/for-ai-agents/legibility-auditor/")}>The Legibility Auditor &rarr;</a>
+  </nav>
+</SubpageLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/for-ai-agents/extraction-agent.astro
+++ b/book-website/src/pages/for-ai-agents/extraction-agent.astro
@@ -1,0 +1,105 @@
+---
+import SubpageLayout from "../../layouts/SubpageLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<SubpageLayout
+  title="The Extraction Agent"
+  description="A role prompt that turns cdad check findings into a prioritized extraction sequence, weighing the legibility signal against business criticality and how often agents touch each capability."
+  section="for-ai-agents"
+>
+  <h1>The Extraction Agent</h1>
+
+  <p>
+    A legibility audit tells you which capabilities are illegible. It
+    doesn't tell you which one to fix first, and in a brownfield
+    codebase with dozens of low scores, that second question is the
+    one that actually blocks progress. The extraction agent's job is to
+    identify the capabilities that should be contracted first, explain
+    why each one is risky, and turn that into a sequencing plan a team
+    can act on instead of arguing about.
+  </p>
+  <p>
+    It always starts from the legibility signal, the scores coming out
+    of the audit or out of <code>cdad check</code>, and then layers in
+    two more inputs before it recommends anything: business criticality
+    and how often agents actually touch that capability. A capability
+    that scores badly but rarely gets touched, by a person or an agent,
+    is a different kind of risk than one that scores badly and sits in
+    the path of every third change anyone makes. The prompt works from
+    the toolkit's real flow: <code>cdad check</code> produces
+    <code>cdad-report.md</code>, <code>cdad roadmap</code> reads that
+    report and turns it into <code>cdad-roadmap.md</code>, and
+    <code>cdad init &lt;capability-id&gt;</code> scaffolds the first
+    contract for whichever capability comes out on top. For the shape
+    of a good handoff, it references
+    <code>templates/audit/legibility-audit.md</code>,
+    <code>templates/extraction-priority/extraction-priority-matrix.md</code>,
+    and the payment-retry worked example.
+  </p>
+  <p>
+    What it produces is a prioritized extraction plan with four parts:
+    the capability IDs that should be contracted first, the specific
+    risk or missing tribal knowledge that makes each one urgent, a
+    recommended phase ordering across the whole set, and the first
+    capture note the team should preserve while the contract gets
+    authored, so the knowledge doesn't evaporate between the audit and
+    the actual writing.
+  </p>
+  <p>
+    It's also built to prevent three specific mistakes. It won't
+    prioritize by code churn alone without legibility evidence backing
+    it up, because a file that changes often isn't automatically a file
+    nobody understands. It won't select a capability just because it
+    scored badly if there's no business criticality attached to it. And
+    it won't recommend extraction without naming what tribal knowledge
+    would otherwise be lost, because a recommendation without that
+    reasoning is just a ranking nobody can defend later.
+  </p>
+  <p>
+    In the workflow, this prompt runs right after <code>cdad
+    check</code> has produced its report, either before
+    <code>cdad roadmap</code> or alongside it. Its output is what a team
+    actually hands to the contract author: not a vague sense that
+    "the payments code is scary," but a specific capability ID, a
+    specific reason, and a place to start.
+  </p>
+
+  <BuyLinks />
+
+  <nav class="chapter-nav" aria-label="Related pages">
+    <a href={withBase("/for-ai-agents/legibility-auditor/")}>&larr; The Legibility Auditor</a>
+    <a href={withBase("/for-ai-agents/contract-maintenance-agent/")}>The Contract Maintenance Agent &rarr;</a>
+  </nav>
+</SubpageLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/for-ai-agents/index.astro
+++ b/book-website/src/pages/for-ai-agents/index.astro
@@ -1,0 +1,144 @@
+---
+import SubpageLayout from "../../layouts/SubpageLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+
+const toc = [
+  { href: "#overview", label: "Overview" },
+  { href: "#pages-in-this-area", label: "Pages in this area" },
+];
+---
+
+<SubpageLayout
+  title="For AI Agents"
+  description="C-DAD ships six ready-to-use agent role prompts, not just a CLI for humans. Here's what each one does, grounded in the toolkit's real schemas and templates."
+  section="for-ai-agents"
+  toc={toc}
+>
+  <h1>For AI Agents</h1>
+
+  <section id="overview">
+    <h2>Overview</h2>
+    <p>
+      Most of this site talks about C-DAD from a practitioner's chair:
+      the person running <code>cdad check</code>, reading the report,
+      deciding what to contract next. But the toolkit doesn't stop at a
+      CLI a human types into. It ships six role prompts, plain markdown
+      files that work as Claude Projects instructions, Cursor rules, or
+      a Codex system prompt, each one written to do a specific job in
+      the contract-driven workflow. They aren't generic "act as a
+      software engineer" prompts. Every one of them is grounded in the
+      toolkit's actual schemas, its worked examples, its CLI reference,
+      and its own generated artifacts, so an agent running one of these
+      prompts is reasoning from the same source of truth a practitioner
+      would be reading.
+    </p>
+    <p>
+      The six roles split cleanly by what they touch. Five of them,
+      the contract author, the contract reviewer, the legibility
+      auditor, the extraction agent, and the contract maintenance
+      agent, operate on contracts and audits rather than on
+      application code. The sixth, the contract-aware coding agent, is
+      the one that actually edits files, and it treats every contract
+      it finds as the boundary of what it's allowed to change. None of
+      them work in isolation. They compose into the same <code>check</code>
+      to <code>roadmap</code> to <code>init</code> to <code>validate</code>
+      to <code>graph</code> loop the rest of the toolkit runs on, so
+      picking the right prompt for the moment is mostly a matter of
+      knowing where in that loop you currently stand.
+    </p>
+  </section>
+
+  <section id="pages-in-this-area">
+    <h2>Pages in this area</h2>
+    <ul class="cluster-list">
+      <li>
+        <a href={withBase("/for-ai-agents/contract-aware-coding-agent/")}>The Contract-Aware Coding Agent</a>
+        <p>The day-to-day implementation agent. It checks the relevant contract before touching code and never widens behavior without updating that contract first.</p>
+      </li>
+      <li>
+        <a href={withBase("/for-ai-agents/contract-author/")}>The Contract Author</a>
+        <p>Turns business intent into a complete contract.yaml, asking for capability ID, intent, inputs and outputs, non-goals, and constraint history, never implementation detail.</p>
+      </li>
+      <li>
+        <a href={withBase("/for-ai-agents/contract-reviewer/")}>The Contract Reviewer</a>
+        <p>Reviews a contract in a fixed order: missing fields, implementation language disguised as intent, unsupported claims, missing constraints, then state mismatches.</p>
+      </li>
+      <li>
+        <a href={withBase("/for-ai-agents/legibility-auditor/")}>The Legibility Auditor</a>
+        <p>Runs the book's four-question audit verbatim, starting from the diagnostic question, and ranks capabilities by how urgently each one needs extraction.</p>
+      </li>
+      <li>
+        <a href={withBase("/for-ai-agents/extraction-agent/")}>The Extraction Agent</a>
+        <p>Turns cdad check findings into a prioritized extraction sequence, weighing the legibility signal against business criticality and agent touchpoint frequency.</p>
+      </li>
+      <li>
+        <a href={withBase("/for-ai-agents/contract-maintenance-agent/")}>The Contract Maintenance Agent</a>
+        <p>Finds drift between contract.yaml, the code, and its generated json and markdown siblings, then recommends the exact semver bump to fix it.</p>
+      </li>
+    </ul>
+  </section>
+
+  <BuyLinks />
+
+  <nav class="chapter-nav" aria-label="Related pages">
+    <a href={withBase("/proof/")}>&larr; Proof</a>
+    <a href={withBase("/toolkit/")}>Toolkit &rarr;</a>
+  </nav>
+</SubpageLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .cluster-list {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 1.25rem;
+    margin: 1.5rem 0;
+  }
+
+  .cluster-list a {
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: var(--border);
+    text-underline-offset: 0.15em;
+  }
+
+  .cluster-list a:hover {
+    color: var(--coral);
+    text-decoration-color: currentColor;
+  }
+
+  .cluster-list p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>

--- a/book-website/src/pages/for-ai-agents/legibility-auditor.astro
+++ b/book-website/src/pages/for-ai-agents/legibility-auditor.astro
@@ -1,0 +1,105 @@
+---
+import SubpageLayout from "../../layouts/SubpageLayout.astro";
+import BuyLinks from "../../components/BuyLinks.astro";
+import { withBase } from "../../utils/url";
+---
+
+<SubpageLayout
+  title="The Legibility Auditor"
+  description="A role prompt that runs the book's four-question legibility audit verbatim against a codebase, starting from the diagnostic question, and ranks capabilities by how urgently they need extraction."
+  section="for-ai-agents"
+>
+  <h1>The Legibility Auditor</h1>
+
+  <p>
+    The legibility auditor's entire job is to run one specific audit,
+    the four-question framework from the book's Appendix B, against a
+    software system or codebase, and the prompt is unusually strict
+    about wording: it's instructed not to paraphrase the diagnostic
+    question or the four follow-up questions, and to use them exactly
+    as written. That's not a stylistic preference. The questions were
+    written precisely enough that rewording them changes what they're
+    actually testing.
+  </p>
+  <p>
+    Every assessment starts with the same diagnostic question: could
+    you hand this capability to a capable engineer who has never spoken
+    to anyone on your team, and have them make a safe change to it
+    using only what the system makes available? If the answer is yes
+    without hesitation, the capability scores a full 4 out of 4 and the
+    auditor moves on. Most capabilities don't clear that bar cleanly,
+    which is where the four follow-up questions come in.
+  </p>
+  <p>
+    Each follow-up targets a different kind of missing knowledge. Can
+    someone understand why the capability works this way, not just
+    what it does, which is business rules legibility. Can someone
+    identify what was tried before, what failed, and why, without
+    asking anyone who was there, which is constraint history
+    legibility. Can someone understand why this capability calls what
+    it calls, in the way it does, rather than the more obvious
+    alternative, which is dependency rationale legibility. And can
+    someone identify every code path that exists because of a specific
+    customer, regulatory, or historical condition without relying on
+    tribal knowledge, which is exception logic legibility.
+  </p>
+  <p>
+    What comes out the other end is a completed audit table for each
+    capability assessed, plus a ranked list ordered by score ascending,
+    so the lowest-scoring capabilities surface first as the highest
+    priority for extraction. The auditor doesn't stop at the number. It
+    also names the specific tribal knowledge that's missing for each
+    capability, meaning it says what an agent would actually fail to
+    find, not just that something scored low. When the practitioner
+    wants a reusable artifact out of this, the prompt points at
+    <code>templates/audit/legibility-audit.md</code> or
+    <code>templates/audit/legibility-audit.csv</code> for the output
+    shape.
+  </p>
+  <p>
+    This audit is the same interview <code>cdad check</code> runs
+    automatically against up to five capabilities by default, so
+    running the legibility auditor by hand is a way to extend that same
+    diagnostic to more capabilities, or to walk through it with more
+    narrative detail than a CLI report gives you. Either way, its
+    output is what the extraction agent reads next to build an actual
+    sequencing plan.
+  </p>
+
+  <BuyLinks />
+
+  <nav class="chapter-nav" aria-label="Related pages">
+    <a href={withBase("/for-ai-agents/contract-reviewer/")}>&larr; The Contract Reviewer</a>
+    <a href={withBase("/for-ai-agents/extraction-agent/")}>The Extraction Agent &rarr;</a>
+  </nav>
+</SubpageLayout>
+
+<style>
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-elev);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25em;
+  }
+
+  .chapter-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .chapter-nav a {
+    text-decoration: none;
+    color: var(--text-muted);
+  }
+
+  .chapter-nav a:hover {
+    color: var(--coral);
+  }
+</style>


### PR DESCRIPTION
## Summary
- **SEO groundwork**: adds `@astrojs/sitemap` (auto-generates `sitemap-index.xml`, all 87 pages), `robots.txt`, canonical URLs, and Open Graph/Twitter card meta on every page. None of this existed before.
- **Navigation overhaul**: restructures the header and footer around 6 real top-level pillars (The Book, Why C-DAD, The Model, How It Works, For AI Agents, Proof) instead of a header pointing only at book-marketing pages and a footer sampling 4 arbitrary link groups. `siteSections.ts` now carries a `pillar` field per section and exports the `PILLARS` themselves, so Header/Footer derive their nav from the same data instead of drifting from it. Every footer column shows every section that belongs to that pillar, nothing stays invisible from global nav (Chapters and Toolkit included).
- **New "For AI Agents" cluster** (7 pages): grounded in the toolkit's real, working agent-role prompts in `claude-configs/` and `agent-configs/` (contract author, contract reviewer, legibility auditor, extraction agent, contract maintenance agent, contract-aware coding agent), none of which were represented anywhere on the site before.
- **2 new Core Model pages**: Extended Contract Fields and Contract Versioning, mined from `docs/contract-schema-reference.md` and `docs/semver-for-contracts.md`.
- **Fixed fabricated content**: the payment-retry example page and two appendix pages referenced a fictional "Meridian" company invented earlier in the project. All three now point at the toolkit's actual real worked example (`payment/retry`), including the real 2022-03-14 incident (47 customers double-charged, $23K impact, ticket PRO-8821) from `templates/worked-examples/payment-retry-extended/`.

## Test plan
- [x] `astro build` completes cleanly, 87 pages generated (up from 78)
- [x] `sitemap-index.xml` / `sitemap-0.xml` contain all 87 URLs
- [x] Site-wide compliance sweep: zero em dashes, zero prose semicolons
- [x] Zero broken internal links across all 87 pages (checked every `href` against the actual built output)
- [x] Verified in browser: header shows all 6 pillars with correct active-state highlighting, footer shows all 6 pillars with real sub-section clusters, canonical/OG meta render correctly, no console errors, mobile layout intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)