### PR TITLE
Remove redundant CTA, cap hero/content width, link persona tiles

### DIFF
--- a/book-website/src/components/AudienceGrid.astro
+++ b/book-website/src/components/AudienceGrid.astro
@@ -2,19 +2,19 @@
 import { withBase } from "../utils/url";
 
 const tiles = [
-  { title: "Software\nDevelopers", tag: "SOFTWARE ENGINEERS", color: "pink", image: "/images/team-developers.jpg" },
-  { title: "Project\nManagers", tag: "PROJECT OWNERS", color: "sage", image: "/images/team-project-managers.jpg" },
-  { title: "Software\nArchitects", tag: "TECH LEADS", color: "gray", image: "/images/team-architects.jpg" },
-  { title: "UI/XD\nDesigners", tag: "SOFTWARE ENGINEERS", color: "tan", image: "/images/team-designers.jpg" },
-  { title: "Leadership\nTeams", tag: "CEOs, CTOs", color: "coral", image: "/images/team-leadership.jpg" },
-  { title: "Engineering\nManagers", tag: "ENGINEERING DIRECTORS", color: "pink", image: "/images/team-engineering-managers.jpg" },
+  { title: "Software\nDevelopers", tag: "SOFTWARE ENGINEERS", color: "pink", image: "/images/team-developers.jpg", href: "/for-developers/" },
+  { title: "Project\nManagers", tag: "PROJECT OWNERS", color: "sage", image: "/images/team-project-managers.jpg", href: "/for-product-managers/" },
+  { title: "Software\nArchitects", tag: "TECH LEADS", color: "gray", image: "/images/team-architects.jpg", href: "/for-architects/" },
+  { title: "UI/XD\nDesigners", tag: "SOFTWARE ENGINEERS", color: "tan", image: "/images/team-designers.jpg", href: "/for-designers/" },
+  { title: "Leadership\nTeams", tag: "CEOs, CTOs", color: "coral", image: "/images/team-leadership.jpg", href: "/for-engineering-leaders/" },
+  { title: "Engineering\nManagers", tag: "ENGINEERING DIRECTORS", color: "pink", image: "/images/team-engineering-managers.jpg", href: "/for-engineering-leaders/" },
 ];
 ---
 
 <div class="audience-grid">
   {
     tiles.map((tile) => (
-      <div class="tile">
+      <a class="tile" href={withBase(tile.href)}>
         <div class={`tile__header tile__header--${tile.color}`}>
           <p class="tile__tag">
             <span class="tick" aria-hidden="true" />
@@ -29,8 +29,10 @@ const tiles = [
             ))}
           </h3>
         </div>
-        <img class="tile__image" src={withBase(tile.image)} alt="" loading="lazy" />
-      </div>
+        <div class={`tile__image-wrap tile__image-wrap--${tile.color}`}>
+          <img class="tile__image" src={withBase(tile.image)} alt="" loading="lazy" />
+        </div>
+      </a>
     ))
   }
 </div>
@@ -43,10 +45,13 @@ const tiles = [
   }
 
   .tile {
+    display: block;
     border-radius: 0.75rem;
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    color: inherit;
+    text-decoration: none;
   }
 
   .tile__header {
@@ -86,11 +91,35 @@ const tiles = [
     line-height: 1.2;
   }
 
+  .tile__image-wrap {
+    position: relative;
+    aspect-ratio: 4 / 3;
+    overflow: hidden;
+  }
+
+  .tile__image-wrap::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    mix-blend-mode: color;
+  }
+
+  .tile__image-wrap--pink::after { background: var(--pink); }
+  .tile__image-wrap--sage::after { background: var(--sage); }
+  .tile__image-wrap--gray::after { background: var(--gray-light); }
+  .tile__image-wrap--tan::after { background: var(--tan); }
+  .tile__image-wrap--coral::after { background: var(--coral); }
+
   .tile__image {
     width: 100%;
-    aspect-ratio: 4 / 3;
+    height: 100%;
     object-fit: cover;
     display: block;
+    filter: grayscale(1) contrast(1.05);
+  }
+
+  .tile:hover .tile__image {
+    filter: grayscale(0.6) contrast(1.05);
   }
 
   @media (max-width: 720px) {

--- a/book-website/src/components/Footer.astro
+++ b/book-website/src/components/Footer.astro
@@ -98,7 +98,7 @@ const contactLinks = [
   }
 
   .footer-inner {
-    max-width: min(100% - 3.5rem, 74rem);
+    max-width: min(100% - 3.5rem, var(--content-width-wide));
     margin: 0 auto;
   }
 

--- a/book-website/src/layouts/SubpageLayout.astro
+++ b/book-website/src/layouts/SubpageLayout.astro
@@ -81,7 +81,7 @@ const hasToc = toc.length > 0;
     display: grid;
     grid-template-columns: minmax(0, 1fr);
     gap: 0 2.5rem;
-    max-width: 78rem;
+    max-width: var(--content-width-wide);
     margin: 0 auto;
     padding: 0 1.5rem;
   }

--- a/book-website/src/pages/index.astro
+++ b/book-website/src/pages/index.astro
@@ -5,7 +5,6 @@ import SectionHeading from "../components/SectionHeading.astro";
 import PanelSection from "../components/PanelSection.astro";
 import CardRow from "../components/CardRow.astro";
 import AudienceGrid from "../components/AudienceGrid.astro";
-import BuyLinks from "../components/BuyLinks.astro";
 import { withBase } from "../utils/url";
 
 // Section copy is written from the book's own manuscript (Chapters 1-5),
@@ -188,13 +187,6 @@ const heroTiming = `
     </div>
   </section>
 
-  <section class="cta">
-    <div class="wrap">
-      <h2>Get the book.</h2>
-      <p class="cta__subtitle">A concrete recipe for every role in a software organization, read the opening chapter free.</p>
-      <BuyLinks />
-    </div>
-  </section>
 </BaseLayout>
 
 <script>
@@ -237,7 +229,8 @@ const heroTiming = `
 <style>
   .hero-wrap {
     position: relative;
-    margin: calc(-1 * var(--header-height)) 0 0;
+    max-width: 1400px;
+    margin: calc(-1 * var(--header-height)) auto 0;
   }
 
   .hero {
@@ -451,30 +444,4 @@ const heroTiming = `
     margin: 0 auto;
   }
 
-  .cta {
-    background: var(--coral);
-    color: #201008;
-    text-align: center;
-    padding: 6rem 0;
-  }
-
-  .cta h2 {
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
-    margin-bottom: 0.75rem;
-  }
-
-  .cta__subtitle {
-    max-width: 32rem;
-    margin: 0 auto 1.5rem;
-    opacity: 0.85;
-  }
-
-  .cta :global(.btn--coral) {
-    background: #201008;
-    color: #f5f3ee;
-  }
-
-  .cta :global(.btn--outline) {
-    border-color: rgba(32, 16, 8, 0.4);
-  }
 </style>

--- a/book-website/src/styles/global.css
+++ b/book-website/src/styles/global.css
@@ -18,6 +18,7 @@
   --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", "Roboto Mono", monospace;
   --content-width: 46rem;
+  --content-width-wide: 73.75rem;
   --header-height: 4rem;
 }
 
@@ -77,7 +78,7 @@ a {
 }
 
 .wrap--wide {
-  max-width: 72rem;
+  max-width: var(--content-width-wide);
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- Removed the redundant "Get the book." CTA band, it duplicated the footer's own featured-book panel directly below it (same message, same buttons, back to back)
- Homepage hero now caps at `max-width: 1400px` instead of stretching full-bleed on ultra-wide monitors
- Standardized the site's wide-content max-width to `73.75rem` (1180px) via a new `--content-width-wide` variable, matching UMA's actual content width, replacing three drifted hardcoded values (72rem, 78rem, 74rem) across `.wrap--wide`, the SubpageLayout page-shell, and the footer
- The 6 "Who is this book for" persona tiles now link to their matching chapter page, and their photos get a duotone filter (grayscale + `mix-blend-mode: color` in the tile's own accent color) matching the Figma reference exactly, they were flat and untinted before

## Test plan
- [x] `astro build` completes cleanly, 87 pages generated
- [x] Verified in browser: hero measures exactly 1400px on a 1700px viewport, `.page-shell` measures exactly 1180px, CTA section confirmed removed from DOM
- [x] All 6 persona tiles confirmed linking to the correct chapter page
- [x] Duotone filter verified visually, matches the Figma reference (pink/sage/gray/tan/coral tints per tile)
- [x] No console errors, mobile layout intact, no em dashes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)