### PR TITLE
Add Google Analytics tracking to every page

### DIFF
--- a/book-website/src/layouts/BaseLayout.astro
+++ b/book-website/src/layouts/BaseLayout.astro
@@ -39,6 +39,17 @@ const websiteSchema = {
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WF2S2Q2494"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-WF2S2Q2494");
+    </script>
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL} />


### PR DESCRIPTION
## Summary
Adds the gtag.js (GA4) snippet to `BaseLayout`'s `<head>`, which every page routes through, the homepage directly and everything else via `SubpageLayout`, plus the 404 page. One change covers all 88 pages instead of adding it per-page.

## Test plan
- [x] `astro build` completes cleanly, 88 pages generated
- [x] Confirmed all 88 built HTML files contain the tracking ID (`grep -rl` count matches total page count exactly)
- [x] Verified in browser: `window.gtag` is a function, `dataLayer` populated, script tag present, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)