### PR TITLE
Exclude book-website from the Jekyll docs-site build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ kramdown:
   input: GFM
 permalink: pretty
 exclude:
+  - book-website
   - cli
   - node_modules
   - openspec


### PR DESCRIPTION
## Summary
- The "Docs Site" workflow (`docs-site.yml`) has failed on every run since it was introduced in #51 — Jekyll scans the whole repo except `_config.yml`'s `exclude` list, which never included `book-website/`
- Jekyll was walking into `book-website/src/**/*.astro` and misreading Astro's `---` component script fences as YAML front matter, erroring on every `.astro` file it touched
- Added `book-website` to the exclude list

Unrelated to the book website itself — this only affects the separate Jekyll-built docs site.

## Test plan
- [x] Manually dispatched the workflow on this branch (run [30684968147](https://github.com/enricopiovesan/the-day-after-toolkit/actions/runs/30684968147)) — the "Build with Jekyll" step now passes with no YAML errors
- [x] The `deploy` step on that manual run failed only due to the `github-pages` environment's branch-protection rule (deploys are restricted to `main`), which is expected and will resolve once this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)