### PR TITLE
Stop docs-site.yml from deploying to Pages

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -1,5 +1,15 @@
 name: Docs Site
 
+# Build-only: a GitHub Pages site can only have one active deployment
+# source per repo. book-website-deploy.yml already owns that slot (it's
+# the live site at thedayafteraibook.com). This workflow used to also
+# deploy to Pages, and since both fired on every push to main with no
+# ordering between them, they raced — whichever finished last silently
+# overwrote the other's deployment, which took the live site down with
+# a 404 (the Jekyll build has no homepage at the domain root).
+#
+# This still builds the Jekyll site on every push as a validation check
+# (catches broken Jekyll config/content) without ever publishing it.
 on:
   push:
     branches:
@@ -8,12 +18,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: docs-site
-  cancel-in-progress: true
 
 jobs:
   build:
@@ -22,27 +26,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
-
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./
           destination: ./_site
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./_site
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- `docs-site.yml` and `book-website-deploy.yml` both deployed to the same GitHub Pages target on every push to `main`, with no ordering between them — this is the conflict the book-website README already warned about as a future risk.
- Merging #69 triggered both simultaneously; `docs-site.yml`'s Jekyll build won the race a moment later and silently overwrote `book-website-deploy.yml`'s deployment, taking `thedayafteraibook.com` down with a 404 (the Jekyll build has no homepage at the domain root).
- `docs-site.yml` now only builds the Jekyll site as a validation check (catches broken Jekyll config/content) and never calls `deploy-pages`, so `book-website-deploy.yml` is the sole owner of the Pages deployment going forward.

The live site is already restored via a manual re-run of `book-website-deploy.yml` — this PR prevents it from breaking again on the next push to `main`.

## Test plan
- [x] Validated the edited workflow YAML parses correctly
- [ ] Confirm `Docs Site` check still runs (build-only) and `book-website-deploy.yml` remains the only workflow touching the `github-pages` deployment environment after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)